### PR TITLE
Add NEON strip assembly helper and test

### DIFF
--- a/libtiff/CMakeLists.txt
+++ b/libtiff/CMakeLists.txt
@@ -47,6 +47,7 @@ set(tiff_private_HEADERS
         tiffiop.h
         uvcode.h
         tif_bayer.h
+        strip_neon.h
         ${CMAKE_CURRENT_BINARY_DIR}/tif_config.h)
 
 
@@ -90,6 +91,7 @@ target_sources(tiff PRIVATE
         tif_read.c
         tif_strip.c
         tif_swab.c
+        tif_strip_neon.c
         tif_thunder.c
         tif_tile.c
         tif_version.c

--- a/libtiff/Makefile.am
+++ b/libtiff/Makefile.am
@@ -53,7 +53,8 @@ noinst_HEADERS = \
         tif_predict.h \
         tiffiop.h \
         uvcode.h \
-        tif_bayer.h
+        tif_bayer.h \
+        strip_neon.h
 
 nodist_libtiffinclude_HEADERS = \
 	tiffconf.h
@@ -91,8 +92,9 @@ libtiff_la_SOURCES = \
 	tif_predict.c \
 	tif_print.c \
 	tif_read.c \
-	tif_strip.c \
-	tif_swab.c \
+       tif_strip.c \
+       tif_strip_neon.c \
+       tif_swab.c \
 	tif_thunder.c \
 	tif_tile.c \
 	tif_version.c \

--- a/libtiff/libtiff.def
+++ b/libtiff/libtiff.def
@@ -197,3 +197,4 @@ EXPORTS	TIFFAccessTagMethods
         _TIFFGetGpsFields
         TIFFPackRaw12
         TIFFUnpackRaw12
+        TIFFAssembleStripNEON

--- a/libtiff/libtiff.map
+++ b/libtiff/libtiff.map
@@ -223,4 +223,5 @@ LIBTIFF_4.7.1 {
     TIFFOpenOptionsSetWarnAboutUnknownTags;
     TIFFPackRaw12;
     TIFFUnpackRaw12;
+    TIFFAssembleStripNEON;
 } LIBTIFF_4.6.1;

--- a/libtiff/strip_neon.h
+++ b/libtiff/strip_neon.h
@@ -1,0 +1,19 @@
+#ifndef STRIP_NEON_H
+#define STRIP_NEON_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t *TIFFAssembleStripNEON(const uint16_t *src, uint32_t width,
+                               uint32_t height, int apply_predictor,
+                               int bigendian, size_t *out_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STRIP_NEON_H */

--- a/libtiff/tif_strip_neon.c
+++ b/libtiff/tif_strip_neon.c
@@ -1,0 +1,63 @@
+#include "tif_bayer.h"
+#include <stdlib.h>
+#include <string.h>
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+#include <arm_neon.h>
+#endif
+
+static void horiz_diff16_neon(uint16_t *row, uint32_t width)
+{
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+    if (width <= 1)
+        return;
+    uint16_t *p = row + 1;
+    uint32_t remaining = width - 1;
+    while (remaining >= 8)
+    {
+        uint16x8_t cur = vld1q_u16(p);
+        uint16x8_t prev = vld1q_u16(p - 1);
+        uint16x8_t diff = vsubq_u16(cur, prev);
+        vst1q_u16(p, diff);
+        p += 8;
+        remaining -= 8;
+    }
+    while (remaining--)
+    {
+        *p = (uint16_t)(*p - *(p - 1));
+        ++p;
+    }
+#else
+    if (width <= 1)
+        return;
+    for (uint32_t i = 1; i < width; i++)
+        row[i] = (uint16_t)(row[i] - row[i - 1]);
+#endif
+}
+
+uint8_t *TIFFAssembleStripNEON(const uint16_t *src, uint32_t width,
+                               uint32_t height, int apply_predictor,
+                               int bigendian, size_t *out_size)
+{
+    size_t count = (size_t)width * height;
+    uint16_t *tmp = (uint16_t *)malloc(count * sizeof(uint16_t));
+    if (!tmp)
+        return NULL;
+    memcpy(tmp, src, count * sizeof(uint16_t));
+    if (apply_predictor)
+    {
+        for (uint32_t row = 0; row < height; row++)
+            horiz_diff16_neon(tmp + row * width, width);
+    }
+    size_t packed_size = ((count + 1) / 2) * 3;
+    uint8_t *packed = (uint8_t *)malloc(packed_size);
+    if (!packed)
+    {
+        free(tmp);
+        return NULL;
+    }
+    TIFFPackRaw12(tmp, packed, count, bigendian);
+    free(tmp);
+    if (out_size)
+        *out_size = packed_size;
+    return packed;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -237,6 +237,12 @@ set_target_properties(swab_neon_test PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(swab_neon_test PRIVATE tiff tiff_port)
 list(APPEND simple_tests swab_neon_test)
 
+add_executable(assemble_strip_neon_test ../placeholder.h)
+target_sources(assemble_strip_neon_test PRIVATE assemble_strip_neon_test.c)
+set_target_properties(assemble_strip_neon_test PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(assemble_strip_neon_test PRIVATE tiff tiff_port)
+list(APPEND simple_tests assemble_strip_neon_test)
+
 add_executable(swab_benchmark ../placeholder.h)
 target_sources(swab_benchmark PRIVATE swab_benchmark.c)
 set_target_properties(swab_benchmark PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -93,7 +93,7 @@ if TIFF_TESTS
 check_PROGRAMS = \
         ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
         defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
-        test_append_to_strip test_ifd_loop_detection swab_neon_test swab_benchmark testtypes test_signed_tags $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
+        test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test swab_benchmark testtypes test_signed_tags $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
 endif
 
 # Test scripts to execute
@@ -304,6 +304,9 @@ test_ifd_loop_detection_LDADD = $(LIBTIFF)
 
 swab_neon_test_SOURCES = swab_neon_test.c
 swab_neon_test_LDADD = $(LIBTIFF)
+
+assemble_strip_neon_test_SOURCES = assemble_strip_neon_test.c
+assemble_strip_neon_test_LDADD = $(LIBTIFF)
 
 swab_benchmark_SOURCES = swab_benchmark.c
 swab_benchmark_LDADD = $(LIBTIFF)

--- a/test/assemble_strip_neon_test.c
+++ b/test/assemble_strip_neon_test.c
@@ -1,0 +1,69 @@
+#include "tiffio.h"
+#include "strip_neon.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+    const uint32_t width = 32;
+    const uint32_t height = 8;
+    size_t count = width * height;
+    uint16_t *buf = (uint16_t *)malloc(count * sizeof(uint16_t));
+    if (!buf)
+        return 1;
+    for (size_t i = 0; i < count; i++)
+        buf[i] = (uint16_t)i;
+
+    size_t strip_size = 0;
+    uint8_t *strip = TIFFAssembleStripNEON(buf, width, height, 0, 1, &strip_size);
+    free(buf);
+    if (!strip)
+        return 1;
+
+    TIFF *tif = TIFFOpen("assemble_strip_neon.tif", "w");
+    if (!tif)
+    {
+        free(strip);
+        return 1;
+    }
+    TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+    TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+    TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+    TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 12);
+    TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+    TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+
+    if (TIFFWriteRawStrip(tif, 0, strip, strip_size) != (tmsize_t)strip_size)
+    {
+        TIFFClose(tif);
+        free(strip);
+        return 1;
+    }
+    TIFFClose(tif);
+
+    tif = TIFFOpen("assemble_strip_neon.tif", "r");
+    if (!tif)
+    {
+        free(strip);
+        return 1;
+    }
+    uint8_t *read_buf = (uint8_t *)malloc(strip_size);
+    if (!read_buf)
+    {
+        TIFFClose(tif);
+        free(strip);
+        return 1;
+    }
+    tmsize_t n = TIFFReadRawStrip(tif, 0, read_buf, strip_size);
+    TIFFClose(tif);
+    int ret = 0;
+    if (n != (tmsize_t)strip_size || memcmp(read_buf, strip, strip_size) != 0)
+        ret = 1;
+    free(read_buf);
+    free(strip);
+    remove("assemble_strip_neon.tif");
+    return ret;
+}


### PR DESCRIPTION
## Summary
- implement `TIFFAssembleStripNEON` to build raw strips using NEON
- expose the function through new `strip_neon.h`
- compile new source in build system
- add test `assemble_strip_neon_test` verifying strip assembly

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684936e23a4483219408b43af65c2746