### PR TITLE
Add SIMD abstraction and SSE4.1 detection

### DIFF
--- a/cmake/ProcessorChecks.cmake
+++ b/cmake/ProcessorChecks.cmake
@@ -45,3 +45,11 @@ check_c_source_compiles(
 if(HAVE_NEON)
   add_compile_definitions(HAVE_NEON=1)
 endif()
+
+check_c_source_compiles(
+  "#include <smmintrin.h>
+   int main(){ __m128i v = _mm_setzero_si128(); return _mm_extract_epi8(v,0); }"
+  HAVE_SSE41)
+if(HAVE_SSE41)
+  add_compile_definitions(HAVE_SSE41=1)
+endif()

--- a/configure.ac
+++ b/configure.ac
@@ -300,6 +300,23 @@ AC_COMPILE_IFELSE([
 ])
 AC_SUBST(HAVE_NEON)
 
+dnl Check for SSE4.1 intrinsics
+AC_MSG_CHECKING([for SSE4.1 support])
+AC_COMPILE_IFELSE([
+  AC_LANG_PROGRAM([
+    #include <smmintrin.h>
+  ],[
+    __m128i v = _mm_setzero_si128(); return _mm_extract_epi8(v,0);
+  ])],[
+  AC_MSG_RESULT(yes)
+  AC_DEFINE([HAVE_SSE41],[1],[Define if SSE4.1 intrinsics are available])
+  HAVE_SSE41=1
+],[
+  AC_MSG_RESULT(no)
+  HAVE_SSE41=0
+])
+AC_SUBST(HAVE_SSE41)
+
 dnl ---------------------------------------------------------------------------
 dnl Enable run-time paths to libraries usage.
 dnl ---------------------------------------------------------------------------

--- a/libtiff/tif_config.h.cmake.in
+++ b/libtiff/tif_config.h.cmake.in
@@ -163,4 +163,7 @@
 /* Define to 1 if ARM NEON intrinsics are available */
 #cmakedefine HAVE_NEON 1
 
+/* Define to 1 if SSE4.1 intrinsics are available */
+#cmakedefine HAVE_SSE41 1
+
 /* clang-format on */

--- a/libtiff/tif_config.h.in
+++ b/libtiff/tif_config.h.in
@@ -179,4 +179,7 @@
 /* Define to 1 if ARM NEON intrinsics are available */
 #undef HAVE_NEON
 
+/* Define to 1 if SSE4.1 intrinsics are available */
+#undef HAVE_SSE41
+
 /* clang-format on */

--- a/libtiff/tiff_simd.h
+++ b/libtiff/tiff_simd.h
@@ -1,0 +1,95 @@
+#ifndef TIFF_SIMD_H
+#define TIFF_SIMD_H
+
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+#include <arm_neon.h>
+#define TIFF_SIMD_NEON 1
+#define TIFF_SIMD_SSE41 0
+#define TIFF_SIMD_ENABLED 1
+typedef uint8x16_t tiff_v16u8;
+static inline tiff_v16u8 tiff_loadu_u8(const uint8_t *ptr)
+{
+    return vld1q_u8(ptr);
+}
+static inline void tiff_storeu_u8(uint8_t *ptr, tiff_v16u8 v)
+{
+    vst1q_u8(ptr, v);
+}
+static inline tiff_v16u8 tiff_add_u8(tiff_v16u8 a, tiff_v16u8 b)
+{
+    return vaddq_u8(a, b);
+}
+static inline tiff_v16u8 tiff_sub_u8(tiff_v16u8 a, tiff_v16u8 b)
+{
+    return vsubq_u8(a, b);
+}
+
+#elif defined(HAVE_SSE41) && (defined(__SSE4_1__) || defined(_MSC_VER))
+#include <smmintrin.h>
+#define TIFF_SIMD_NEON 0
+#define TIFF_SIMD_SSE41 1
+#define TIFF_SIMD_ENABLED 1
+typedef __m128i tiff_v16u8;
+static inline tiff_v16u8 tiff_loadu_u8(const uint8_t *ptr)
+{
+    return _mm_loadu_si128((const __m128i *)ptr);
+}
+static inline void tiff_storeu_u8(uint8_t *ptr, tiff_v16u8 v)
+{
+    _mm_storeu_si128((__m128i *)ptr, v);
+}
+static inline tiff_v16u8 tiff_add_u8(tiff_v16u8 a, tiff_v16u8 b)
+{
+    return _mm_add_epi8(a, b);
+}
+static inline tiff_v16u8 tiff_sub_u8(tiff_v16u8 a, tiff_v16u8 b)
+{
+    return _mm_sub_epi8(a, b);
+}
+
+#else
+#define TIFF_SIMD_NEON 0
+#define TIFF_SIMD_SSE41 0
+#define TIFF_SIMD_ENABLED 0
+typedef struct
+{
+    uint8_t v[16];
+} tiff_v16u8;
+static inline tiff_v16u8 tiff_loadu_u8(const uint8_t *ptr)
+{
+    tiff_v16u8 r;
+    memcpy(r.v, ptr, 16);
+    return r;
+}
+static inline void tiff_storeu_u8(uint8_t *ptr, tiff_v16u8 v)
+{
+    memcpy(ptr, v.v, 16);
+}
+static inline tiff_v16u8 tiff_add_u8(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    for (int i = 0; i < 16; i++)
+        r.v[i] = (uint8_t)(a.v[i] + b.v[i]);
+    return r;
+}
+static inline tiff_v16u8 tiff_sub_u8(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    for (int i = 0; i < 16; i++)
+        r.v[i] = (uint8_t)(a.v[i] - b.v[i]);
+    return r;
+}
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* TIFF_SIMD_H */


### PR DESCRIPTION
## Summary
- add `tiff_simd.h` header with NEON/SSE4.1/Scalar implementations
- detect SSE4.1 intrinsics in configure and CMake
- expose HAVE_SSE41 in generated config headers

## Testing
- `cmake ..`
- `cmake --build . --target tiffinfo`


------
https://chatgpt.com/codex/tasks/task_e_6849389b21dc8321ac1e9913bd21527e