### PR TITLE
Use TIFF allocator helpers in NEON strip assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Float32 predictor decoding on x86‑64 interleaves four vectors at once, yieldin
 ### NEON TIFF Strip Assembly
 `TIFFAssembleStripNEON()` assembles a strip from a 16‑bit buffer and optionally applies the predictor before packing samples to 12‑bit form:
 ```c
-uint8_t *TIFFAssembleStripNEON(const uint16_t *src, uint32_t width,
+uint8_t *TIFFAssembleStripNEON(TIFF *tif, const uint16_t *src, uint32_t width,
                                uint32_t height, int apply_predictor,
                                int bigendian, size_t *out_size);
 ```
@@ -158,7 +158,8 @@ uint32_t width = 64, height = 32;
 uint16_t *buf = malloc(width * height * sizeof(uint16_t));
 /* fill buf */
 size_t strip_size = 0;
-uint8_t *strip = TIFFAssembleStripNEON(buf, width, height, 1, 1, &strip_size);
+uint8_t *strip =
+    TIFFAssembleStripNEON(NULL, buf, width, height, 1, 1, &strip_size);
 
 TIFF *tif = TIFFOpen("out.dng", "w");
 TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);

--- a/libtiff/strip_neon.h
+++ b/libtiff/strip_neon.h
@@ -1,16 +1,19 @@
 #ifndef STRIP_NEON_H
 #define STRIP_NEON_H
 
-#include <stdint.h>
+#include "tiffio.h"
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-uint8_t *TIFFAssembleStripNEON(const uint16_t *src, uint32_t width,
-                               uint32_t height, int apply_predictor,
-                               int bigendian, size_t *out_size);
+    uint8_t *TIFFAssembleStripNEON(TIFF *tif, const uint16_t *src,
+                                   uint32_t width, uint32_t height,
+                                   int apply_predictor, int bigendian,
+                                   size_t *out_size);
 
 #ifdef __cplusplus
 }

--- a/test/assemble_strip_neon_test.c
+++ b/test/assemble_strip_neon_test.c
@@ -1,5 +1,5 @@
-#include "tiffio.h"
 #include "strip_neon.h"
+#include "tiffio.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +16,8 @@ int main(void)
         buf[i] = (uint16_t)i;
 
     size_t strip_size = 0;
-    uint8_t *strip = TIFFAssembleStripNEON(buf, width, height, 0, 1, &strip_size);
+    uint8_t *strip =
+        TIFFAssembleStripNEON(NULL, buf, width, height, 0, 1, &strip_size);
     free(buf);
     if (!strip)
         return 1;


### PR DESCRIPTION
## Summary
- use `_TIFFmallocExt`/`_TIFFfreeExt` in the NEON strip assembly code
- update header and test for new TIFF* parameter
- document updated API in README

## Testing
- `python3 -m pre_commit run --files libtiff/tif_strip_neon.c libtiff/strip_neon.h test/assemble_strip_neon_test.c README.md`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6849e42cd92883219b210795d2a3cf24