### PR TITLE
Document lazy strile loading flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ typedef uint8x16_t tiff_v16u8;
 ### JPEG‑LS Codec Stub
 A placeholder codec integrates with CharLS when available. Configure with `-Djpegls=ON` or `--with-jpegls` to experiment.
 
+### Lazy Strile Loading
+`TIFFOpen()` accepts `'D'` (defer) and `'O'` (on‑demand) mode flags.  `'D'`
+postpones loading the `StripOffsets`/`StripByteCounts` or
+`TileOffsets`/`TileByteCounts` arrays until first use.  `'O'` implies `'D'` and
+only fetches the requested strip or tile entry.  These flags enable lazy
+metadata access and can significantly reduce startup time when files reside on
+slow storage.
+
+See [doc/functions/TIFFStrileQuery.rst](doc/functions/TIFFStrileQuery.rst) for
+details on querying per‑strile information.
+
 ## How to Use SIMD Routines
 Below is a short example that assembles a 12‑bit strip and writes a DNG.
 The full program is [`test/assemble_strip_neon_test.c`](test/assemble_strip_neon_test.c).


### PR DESCRIPTION
## Summary
- describe `D` and `O` flags for `TIFFOpen`
- explain that they defer strip/tile arrays to speed up metadata access
- link to TIFFStrileQuery docs

## Testing
- `pre-commit run --files README.md`

------
https://chatgpt.com/codex/tasks/task_e_684a55b305688321bbe33867a411ae5e