### PR TITLE
Add io_uring state per TIFF handle

### DIFF
--- a/libtiff/tif_close.c
+++ b/libtiff/tif_close.c
@@ -51,6 +51,9 @@ void TIFFCleanup(TIFF *tif)
     TIFFFreeDirectory(tif);
 
     _TIFFCleanupIFDOffsetAndNumberMaps(tif);
+#ifdef USE_IO_URING
+    _tiffUringTeardown(tif);
+#endif
 
     /*
      * Clean up client info links.

--- a/libtiff/tif_unix.c
+++ b/libtiff/tif_unix.c
@@ -235,7 +235,12 @@ TIFF *TIFFFdOpenExt(int fd, const char *name, const char *mode,
                             _tiffSeekProc, _tiffCloseProc, _tiffSizeProc,
                             _tiffMapProc, _tiffUnmapProc, opts);
     if (tif)
+    {
         tif->tif_fd = fd;
+#ifdef USE_IO_URING
+        _tiffUringInit(tif);
+#endif
+    }
     return (tif);
 }
 

--- a/libtiff/tif_uring.c
+++ b/libtiff/tif_uring.c
@@ -4,46 +4,140 @@
 #include <errno.h>
 #include "tiffiop.h"
 
+/* Mapping between file descriptors and their io_uring */
+typedef struct _TIFFURingEntry
+{
+    int fd;
+    struct io_uring *ring;
+    int async;
+    struct _TIFFURingEntry *next;
+} _TIFFURingEntry;
+
+static _TIFFURingEntry *gUringList = NULL;
+
+static _TIFFURingEntry *_tiffUringFind(int fd)
+{
+    _TIFFURingEntry *cur;
+    for (cur = gUringList; cur; cur = cur->next)
+    {
+        if (cur->fd == fd)
+            return cur;
+    }
+    return NULL;
+}
+
+static void _tiffUringAdd(int fd, struct io_uring *ring)
+{
+    _TIFFURingEntry *e = (_TIFFURingEntry *)_TIFFmallocExt(NULL, sizeof(*e));
+    if (!e)
+        return;
+    e->fd = fd;
+    e->ring = ring;
+    e->async = 0;
+    e->next = gUringList;
+    gUringList = e;
+}
+
+static void _tiffUringRemove(int fd)
+{
+    _TIFFURingEntry **pp = &gUringList;
+    while (*pp)
+    {
+        if ((*pp)->fd == fd)
+        {
+            _TIFFURingEntry *tmp = *pp;
+            *pp = tmp->next;
+            _TIFFfreeExt(NULL, tmp);
+            return;
+        }
+        pp = &(*pp)->next;
+    }
+}
+
+int _tiffUringInit(TIFF *tif)
+{
+    tif->tif_uring = (struct io_uring *)_TIFFmallocExt(tif, sizeof(struct io_uring));
+    if (!tif->tif_uring)
+        return 0;
+    if (io_uring_queue_init(8, tif->tif_uring, 0) < 0)
+    {
+        _TIFFfreeExt(tif, tif->tif_uring);
+        tif->tif_uring = NULL;
+        return 0;
+    }
+    tif->tif_uring_async = 0;
+    _tiffUringAdd(tif->tif_fd, tif->tif_uring);
+    return 1;
+}
+
+void _tiffUringTeardown(TIFF *tif)
+{
+    if (!tif->tif_uring)
+        return;
+    _tiffUringRemove(tif->tif_fd);
+    _tiffUringWait(tif);
+    io_uring_queue_exit(tif->tif_uring);
+    _TIFFfreeExt(tif, tif->tif_uring);
+    tif->tif_uring = NULL;
+}
+
+void _tiffUringSetAsync(TIFF *tif, int enable)
+{
+    _TIFFURingEntry *e = _tiffUringFind(tif->tif_fd);
+    if (e)
+        e->async = enable ? 1 : 0;
+    tif->tif_uring_async = enable ? 1 : 0;
+}
+
+void _tiffUringFlush(TIFF *tif)
+{
+    if (tif && tif->tif_uring)
+        io_uring_submit(tif->tif_uring);
+}
+
+void _tiffUringWait(TIFF *tif)
+{
+    if (!tif || !tif->tif_uring)
+        return;
+    struct io_uring_cqe *cqe;
+    while (io_uring_wait_cqe(tif->tif_uring, &cqe) == 0)
+    {
+        io_uring_cqe_seen(tif->tif_uring, cqe);
+    }
+}
+
 static tmsize_t io_uring_rw(int readflag, thandle_t fd, void *buf, tmsize_t size)
 {
-    struct io_uring ring;
-    if (io_uring_queue_init(1, &ring, 0) < 0)
-    {
+    _TIFFURingEntry *e = _tiffUringFind((int)(intptr_t)fd);
+    if (!e)
         return (tmsize_t)-1;
-    }
+    struct io_uring *ring = e->ring;
 
-    struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+    struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
     if (!sqe)
-    {
-        io_uring_queue_exit(&ring);
-        errno = EIO;
         return (tmsize_t)-1;
-    }
+
     if (readflag)
         io_uring_prep_read(sqe, (int)(intptr_t)fd, buf, (unsigned int)size, -1);
     else
         io_uring_prep_write(sqe, (int)(intptr_t)fd, buf, (unsigned int)size, -1);
 
-    if (io_uring_submit_and_wait(&ring, 1) < 0)
-    {
-        io_uring_queue_exit(&ring);
+    if (io_uring_submit(ring) < 0)
         return (tmsize_t)-1;
-    }
+
+    if (e->async)
+        return size;
 
     struct io_uring_cqe *cqe;
-    if (io_uring_peek_cqe(&ring, &cqe) < 0)
-    {
-        io_uring_queue_exit(&ring);
+    if (io_uring_wait_cqe(ring, &cqe) < 0)
         return (tmsize_t)-1;
-    }
     int res = cqe->res;
     if (res < 0)
     {
         errno = -res;
         res = -1;
     }
-    io_uring_cqe_seen(&ring, cqe);
-    io_uring_queue_exit(&ring);
+    io_uring_cqe_seen(ring, cqe);
     return (tmsize_t)res;
 }
 

--- a/libtiff/tiffiop.h
+++ b/libtiff/tiffiop.h
@@ -48,6 +48,9 @@
 
 #include "tif_hash_set.h"
 #include "tiffio.h"
+#ifdef USE_IO_URING
+#include <liburing.h>
+#endif
 
 #include "tif_dir.h"
 
@@ -258,6 +261,10 @@ struct tiff
     tmsize_t tif_max_single_mem_alloc;    /* in bytes. 0 for unlimited */
     tmsize_t tif_max_cumulated_mem_alloc; /* in bytes. 0 for unlimited */
     tmsize_t tif_cur_cumulated_mem_alloc; /* in bytes */
+#ifdef USE_IO_URING
+    struct io_uring *tif_uring; /* persistent io_uring handle */
+    int tif_uring_async;        /* async flush/wait semantics */
+#endif
     int tif_warn_about_unknown_tags;
 };
 
@@ -545,6 +552,13 @@ extern "C"
     extern void *_TIFFcallocExt(TIFF *tif, tmsize_t nmemb, tmsize_t siz);
     extern void *_TIFFreallocExt(TIFF *tif, void *p, tmsize_t s);
     extern void _TIFFfreeExt(TIFF *tif, void *p);
+#ifdef USE_IO_URING
+    extern int _tiffUringInit(TIFF *tif);
+    extern void _tiffUringTeardown(TIFF *tif);
+    extern void _tiffUringSetAsync(TIFF *tif, int enable);
+    extern void _tiffUringFlush(TIFF *tif);
+    extern void _tiffUringWait(TIFF *tif);
+#endif
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary
- keep an `io_uring` instance for every TIFF handle
- expose init/teardown and async helpers
- update Unix open path to create the ring
- use the persistent ring in read/write operations
- shut down the ring when closing TIFF handles

## Testing
- `make -j$(nproc)`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_684a5c146c3083219a9d4073acebe23c