### PR TITLE
Add runtime SIMD initialization

### DIFF
--- a/libtiff/CMakeLists.txt
+++ b/libtiff/CMakeLists.txt
@@ -92,6 +92,7 @@ target_sources(tiff PRIVATE
         tif_strip.c
         tif_swab.c
         tif_strip_neon.c
+        tiff_simd.c
         tif_thunder.c
         tif_tile.c
         tif_version.c

--- a/libtiff/Makefile.am
+++ b/libtiff/Makefile.am
@@ -91,10 +91,11 @@ libtiff_la_SOURCES = \
 	tif_pixarlog.c \
         tif_predict.c \
         tif_print.c \
-        tif_read.c \
-       tif_strip.c \
-       tif_strip_neon.c \
-       tif_swab.c \
+       tif_read.c \
+      tif_strip.c \
+      tif_strip_neon.c \
+       tiff_simd.c \
+      tif_swab.c \
         tif_thunder.c \
         tif_tile.c \
         tif_version.c \

--- a/libtiff/tiff_simd.c
+++ b/libtiff/tiff_simd.c
@@ -1,0 +1,143 @@
+#include "tiff_simd.h"
+#include <string.h>
+#if defined(__linux__)
+#include <sys/auxv.h>
+#endif
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) ||             \
+    defined(_M_IX86)
+#include <cpuid.h>
+#endif
+
+tiff_simd_funcs tiff_simd;
+
+/* Scalar implementations */
+static tiff_v16u8 loadu_u8_scalar(const uint8_t *ptr)
+{
+    tiff_v16u8 r;
+    memcpy(r.v, ptr, 16);
+    return r;
+}
+
+static void storeu_u8_scalar(uint8_t *ptr, tiff_v16u8 v)
+{
+    memcpy(ptr, v.v, 16);
+}
+
+static tiff_v16u8 add_u8_scalar(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    for (int i = 0; i < 16; i++)
+        r.v[i] = (uint8_t)(a.v[i] + b.v[i]);
+    return r;
+}
+
+static tiff_v16u8 sub_u8_scalar(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    for (int i = 0; i < 16; i++)
+        r.v[i] = (uint8_t)(a.v[i] - b.v[i]);
+    return r;
+}
+
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+#include <arm_neon.h>
+static tiff_v16u8 loadu_u8_neon(const uint8_t *ptr)
+{
+    tiff_v16u8 r;
+    r.n = vld1q_u8(ptr);
+    return r;
+}
+static void storeu_u8_neon(uint8_t *ptr, tiff_v16u8 v) { vst1q_u8(ptr, v.n); }
+static tiff_v16u8 add_u8_neon(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    r.n = vaddq_u8(a.n, b.n);
+    return r;
+}
+static tiff_v16u8 sub_u8_neon(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    r.n = vsubq_u8(a.n, b.n);
+    return r;
+}
+#endif
+
+#if defined(HAVE_SSE41)
+#include <smmintrin.h>
+static tiff_v16u8 loadu_u8_sse41(const uint8_t *ptr)
+{
+    tiff_v16u8 r;
+    r.x = _mm_loadu_si128((const __m128i *)ptr);
+    return r;
+}
+static void storeu_u8_sse41(uint8_t *ptr, tiff_v16u8 v)
+{
+    _mm_storeu_si128((__m128i *)ptr, v.x);
+}
+static tiff_v16u8 add_u8_sse41(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    r.x = _mm_add_epi8(a.x, b.x);
+    return r;
+}
+static tiff_v16u8 sub_u8_sse41(tiff_v16u8 a, tiff_v16u8 b)
+{
+    tiff_v16u8 r;
+    r.x = _mm_sub_epi8(a.x, b.x);
+    return r;
+}
+#endif
+
+static int detect_neon(void)
+{
+#if defined(HAVE_NEON) && defined(__linux__)
+#ifdef __aarch64__
+#ifdef HWCAP_ASIMD
+    return (getauxval(AT_HWCAP) & HWCAP_ASIMD) != 0;
+#endif
+#elif defined(__arm__)
+#ifdef HWCAP_NEON
+    return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0;
+#endif
+#endif
+#endif
+    return 0;
+}
+
+static int detect_sse41(void)
+{
+#if defined(HAVE_SSE41) && (defined(__x86_64__) || defined(__i386__) ||        \
+                            defined(_M_X64) || defined(_M_IX86))
+    unsigned int eax, ebx, ecx, edx;
+    if (__get_cpuid(1, &eax, &ebx, &ecx, &edx))
+        return (ecx & bit_SSE4_1) != 0;
+#endif
+    return 0;
+}
+
+void TIFFInitSIMD(void)
+{
+    tiff_simd.loadu_u8 = loadu_u8_scalar;
+    tiff_simd.storeu_u8 = storeu_u8_scalar;
+    tiff_simd.add_u8 = add_u8_scalar;
+    tiff_simd.sub_u8 = sub_u8_scalar;
+#if defined(HAVE_NEON)
+    if (detect_neon())
+    {
+        tiff_simd.loadu_u8 = loadu_u8_neon;
+        tiff_simd.storeu_u8 = storeu_u8_neon;
+        tiff_simd.add_u8 = add_u8_neon;
+        tiff_simd.sub_u8 = sub_u8_neon;
+        return;
+    }
+#endif
+#if defined(HAVE_SSE41)
+    if (detect_sse41())
+    {
+        tiff_simd.loadu_u8 = loadu_u8_sse41;
+        tiff_simd.storeu_u8 = storeu_u8_sse41;
+        tiff_simd.add_u8 = add_u8_sse41;
+        tiff_simd.sub_u8 = sub_u8_sse41;
+    }
+#endif
+}

--- a/libtiff/tiff_simd.h
+++ b/libtiff/tiff_simd.h
@@ -2,91 +2,71 @@
 #define TIFF_SIMD_H
 
 #include <stdint.h>
-#include <string.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if defined(HAVE_NEON) && defined(__ARM_NEON)
 #include <arm_neon.h>
-#define TIFF_SIMD_NEON 1
-#define TIFF_SIMD_SSE41 0
-#define TIFF_SIMD_ENABLED 1
-typedef uint8x16_t tiff_v16u8;
-static inline tiff_v16u8 tiff_loadu_u8(const uint8_t *ptr)
-{
-    return vld1q_u8(ptr);
-}
-static inline void tiff_storeu_u8(uint8_t *ptr, tiff_v16u8 v)
-{
-    vst1q_u8(ptr, v);
-}
-static inline tiff_v16u8 tiff_add_u8(tiff_v16u8 a, tiff_v16u8 b)
-{
-    return vaddq_u8(a, b);
-}
-static inline tiff_v16u8 tiff_sub_u8(tiff_v16u8 a, tiff_v16u8 b)
-{
-    return vsubq_u8(a, b);
-}
-
-#elif defined(HAVE_SSE41) && (defined(__SSE4_1__) || defined(_MSC_VER))
+#endif
+#if defined(HAVE_SSE41)
 #include <smmintrin.h>
-#define TIFF_SIMD_NEON 0
-#define TIFF_SIMD_SSE41 1
-#define TIFF_SIMD_ENABLED 1
-typedef __m128i tiff_v16u8;
-static inline tiff_v16u8 tiff_loadu_u8(const uint8_t *ptr)
-{
-    return _mm_loadu_si128((const __m128i *)ptr);
-}
-static inline void tiff_storeu_u8(uint8_t *ptr, tiff_v16u8 v)
-{
-    _mm_storeu_si128((__m128i *)ptr, v);
-}
-static inline tiff_v16u8 tiff_add_u8(tiff_v16u8 a, tiff_v16u8 b)
-{
-    return _mm_add_epi8(a, b);
-}
-static inline tiff_v16u8 tiff_sub_u8(tiff_v16u8 a, tiff_v16u8 b)
-{
-    return _mm_sub_epi8(a, b);
-}
+#endif
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if defined(HAVE_NEON)
+#define TIFF_SIMD_NEON 1
 #else
 #define TIFF_SIMD_NEON 0
-#define TIFF_SIMD_SSE41 0
-#define TIFF_SIMD_ENABLED 0
-typedef struct
-{
-    uint8_t v[16];
-} tiff_v16u8;
-static inline tiff_v16u8 tiff_loadu_u8(const uint8_t *ptr)
-{
-    tiff_v16u8 r;
-    memcpy(r.v, ptr, 16);
-    return r;
-}
-static inline void tiff_storeu_u8(uint8_t *ptr, tiff_v16u8 v)
-{
-    memcpy(ptr, v.v, 16);
-}
-static inline tiff_v16u8 tiff_add_u8(tiff_v16u8 a, tiff_v16u8 b)
-{
-    tiff_v16u8 r;
-    for (int i = 0; i < 16; i++)
-        r.v[i] = (uint8_t)(a.v[i] + b.v[i]);
-    return r;
-}
-static inline tiff_v16u8 tiff_sub_u8(tiff_v16u8 a, tiff_v16u8 b)
-{
-    tiff_v16u8 r;
-    for (int i = 0; i < 16; i++)
-        r.v[i] = (uint8_t)(a.v[i] - b.v[i]);
-    return r;
-}
 #endif
+#if defined(HAVE_SSE41)
+#define TIFF_SIMD_SSE41 1
+#else
+#define TIFF_SIMD_SSE41 0
+#endif
+#if TIFF_SIMD_NEON || TIFF_SIMD_SSE41
+#define TIFF_SIMD_ENABLED 1
+#else
+#define TIFF_SIMD_ENABLED 0
+#endif
+
+    typedef union
+    {
+        uint8_t v[16];
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+        uint8x16_t n;
+#endif
+#if defined(HAVE_SSE41)
+        __m128i x;
+#endif
+    } tiff_v16u8;
+
+    typedef struct
+    {
+        tiff_v16u8 (*loadu_u8)(const uint8_t *);
+        void (*storeu_u8)(uint8_t *, tiff_v16u8);
+        tiff_v16u8 (*add_u8)(tiff_v16u8, tiff_v16u8);
+        tiff_v16u8 (*sub_u8)(tiff_v16u8, tiff_v16u8);
+    } tiff_simd_funcs;
+
+    extern tiff_simd_funcs tiff_simd;
+
+    static inline tiff_v16u8 tiff_loadu_u8(const uint8_t *p)
+    {
+        return tiff_simd.loadu_u8(p);
+    }
+    static inline void tiff_storeu_u8(uint8_t *p, tiff_v16u8 v)
+    {
+        tiff_simd.storeu_u8(p, v);
+    }
+    static inline tiff_v16u8 tiff_add_u8(tiff_v16u8 a, tiff_v16u8 b)
+    {
+        return tiff_simd.add_u8(a, b);
+    }
+    static inline tiff_v16u8 tiff_sub_u8(tiff_v16u8 a, tiff_v16u8 b)
+    {
+        return tiff_simd.sub_u8(a, b);
+    }
 
 #ifdef __cplusplus
 } // extern "C"

--- a/libtiff/tiffio.h
+++ b/libtiff/tiffio.h
@@ -254,7 +254,7 @@ struct _TIFFRGBAImage
  * Macros for extracting components from the
  * packed ABGR form returned by TIFFReadRGBAImage.
  */
-#define TIFFGetR(abgr) ((abgr)&0xff)
+#define TIFFGetR(abgr) ((abgr) & 0xff)
 #define TIFFGetG(abgr) (((abgr) >> 8) & 0xff)
 #define TIFFGetB(abgr) (((abgr) >> 16) & 0xff)
 #define TIFFGetA(abgr) (((abgr) >> 24) & 0xff)
@@ -569,6 +569,7 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
     /* Thread pool management */
     extern void TIFFSetThreadCount(int);
     extern int TIFFGetThreadCount(void);
+    extern void TIFFInitSIMD(void);
     extern tmsize_t TIFFReadEncodedStrip(TIFF *tif, uint32_t strip, void *buf,
                                          tmsize_t size);
     extern tmsize_t TIFFReadRawStrip(TIFF *tif, uint32_t strip, void *buf,


### PR DESCRIPTION
## Summary
- add new TIFFInitSIMD() API for runtime feature detection
- select NEON or SSE4.1 vector helpers via function pointers
- compile new tiff_simd.c and hook into build scripts

## Testing
- `cmake ..`
- `cmake --build . -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684a638aac20832197bb0f87f25c4e88