### PR TITLE
Add predictor and io_uring benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,17 @@ ARM NEON builds on an RK3588 at 2.4 GHz show roughly 6× improvements for
 `TIFFPackRaw12` and 5× for `TIFFUnpackRaw12`. `TIFFSwabArrayOfLong8` is
 around 3× faster than the scalar implementation on the same device.
 
+On a Raspberry Pi 5 you can enable the thread pool and io_uring backends and run
+additional benchmarks:
+
+```bash
+$ cmake -Dthreadpool=ON -Dio-uring=ON -DCMAKE_BUILD_TYPE=Release ..
+$ cmake --build . -j$(nproc)
+
+$ ./test/predictor_threadpool_benchmark 4 50
+$ ./test/pack_uring_benchmark
+```
+
 ## Testing and Validation
 Configure with testing enabled and run the full suite:
 ```bash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -261,6 +261,18 @@ set_target_properties(swab_benchmark PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(swab_benchmark PRIVATE tiff tiff_port)
 list(APPEND simple_tests swab_benchmark)
 
+add_executable(predictor_threadpool_benchmark ../placeholder.h)
+target_sources(predictor_threadpool_benchmark PRIVATE predictor_threadpool_benchmark.c)
+set_target_properties(predictor_threadpool_benchmark PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(predictor_threadpool_benchmark PRIVATE tiff tiff_port)
+list(APPEND simple_tests predictor_threadpool_benchmark)
+
+add_executable(pack_uring_benchmark ../placeholder.h)
+target_sources(pack_uring_benchmark PRIVATE pack_uring_benchmark.c)
+set_target_properties(pack_uring_benchmark PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(pack_uring_benchmark PRIVATE tiff tiff_port)
+list(APPEND simple_tests pack_uring_benchmark)
+
 if(WEBP_SUPPORT AND EMSCRIPTEN)
   # Emscripten is pretty finnicky about linker flags.
   # It needs --shared-memory if and only if atomics or bulk-memory is used.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -103,8 +103,8 @@ endif
 if TIFF_TESTS
 check_PROGRAMS = \
         ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
-        defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
-       test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test swab_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
+       defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
+       test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
 endif
 
 # Test scripts to execute
@@ -327,6 +327,12 @@ gray_flip_neon_test_LDADD = $(LIBTIFF)
 
 swab_benchmark_SOURCES = swab_benchmark.c
 swab_benchmark_LDADD = $(LIBTIFF)
+
+predictor_threadpool_benchmark_SOURCES = predictor_threadpool_benchmark.c
+predictor_threadpool_benchmark_LDADD = $(LIBTIFF)
+
+pack_uring_benchmark_SOURCES = pack_uring_benchmark.c
+pack_uring_benchmark_LDADD = $(LIBTIFF)
 
 AM_CPPFLAGS = -I$(top_srcdir)/libtiff
 

--- a/test/pack_uring_benchmark.c
+++ b/test/pack_uring_benchmark.c
@@ -1,0 +1,90 @@
+#include "strip_neon.h"
+#include "tiffio.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static double elapsed_ms(struct timespec *s, struct timespec *e)
+{
+    return (e->tv_sec - s->tv_sec) * 1000.0 +
+           (e->tv_nsec - s->tv_nsec) / 1000000.0;
+}
+
+int main(void)
+{
+    const char *filename = "uring_pack_bench.tiff";
+    const uint32_t width = 512, height = 512;
+    size_t count = (size_t)width * height;
+    uint16_t *src = (uint16_t *)malloc(count * sizeof(uint16_t));
+    if (!src)
+        return 1;
+    for (size_t i = 0; i < count; i++)
+        src[i] = (uint16_t)(i & 0x0FFF);
+
+    size_t strip_size = 0;
+    uint8_t *packed =
+        TIFFAssembleStripNEON(NULL, src, width, height, 1, 0, &strip_size);
+
+    struct timespec s, e;
+    clock_gettime(CLOCK_MONOTONIC, &s);
+    TIFF *tif = TIFFOpen(filename, "w");
+    if (!tif)
+    {
+        fprintf(stderr, "cannot create %s\n", filename);
+        free(packed);
+        free(src);
+        return 1;
+    }
+    TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+    TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+    TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+    TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 12);
+    TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+    TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    if (TIFFWriteRawStrip(tif, 0, packed, strip_size) != (tmsize_t)strip_size)
+    {
+        fprintf(stderr, "write failed\n");
+        TIFFClose(tif);
+        free(packed);
+        free(src);
+        return 1;
+    }
+    TIFFClose(tif);
+    clock_gettime(CLOCK_MONOTONIC, &e);
+    printf("write: %.2f ms\n", elapsed_ms(&s, &e));
+
+    uint8_t *readbuf = (uint8_t *)malloc(strip_size);
+    clock_gettime(CLOCK_MONOTONIC, &s);
+    tif = TIFFOpen(filename, "r");
+    if (!tif)
+    {
+        fprintf(stderr, "cannot reopen %s\n", filename);
+        free(readbuf);
+        free(packed);
+        free(src);
+        return 1;
+    }
+    if (TIFFReadRawStrip(tif, 0, readbuf, strip_size) != (tmsize_t)strip_size)
+    {
+        fprintf(stderr, "read failed\n");
+        TIFFClose(tif);
+        free(readbuf);
+        free(packed);
+        free(src);
+        return 1;
+    }
+    TIFFClose(tif);
+    clock_gettime(CLOCK_MONOTONIC, &e);
+    printf("read: %.2f ms\n", elapsed_ms(&s, &e));
+
+    int ret = memcmp(readbuf, packed, strip_size) != 0;
+    free(readbuf);
+    free(packed);
+    free(src);
+    unlink(filename);
+    return ret;
+}

--- a/test/predictor_threadpool_benchmark.c
+++ b/test/predictor_threadpool_benchmark.c
@@ -1,0 +1,76 @@
+#include "strip_neon.h"
+#include "tiff_threadpool.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+typedef struct
+{
+    const uint16_t *src;
+    uint32_t width;
+    uint32_t height;
+    size_t loops;
+} Task;
+
+static void bench_task(void *arg)
+{
+    Task *t = (Task *)arg;
+    for (size_t i = 0; i < t->loops; i++)
+    {
+        size_t out_size = 0;
+        uint8_t *dst = TIFFAssembleStripNEON(NULL, t->src, t->width, t->height,
+                                             1, 0, &out_size);
+        free(dst);
+    }
+}
+
+static double elapsed_ms(struct timespec *s, struct timespec *e)
+{
+    return (e->tv_sec - s->tv_sec) * 1000.0 +
+           (e->tv_nsec - s->tv_nsec) / 1000000.0;
+}
+
+int main(int argc, char **argv)
+{
+    int threads = 4;
+    size_t loops = 50;
+    if (argc > 1)
+        threads = atoi(argv[1]);
+    if (argc > 2)
+        loops = (size_t)atoi(argv[2]);
+
+    _TIFFThreadPoolInit(threads);
+
+    const uint32_t width = 512, height = 512;
+    size_t count = (size_t)width * height;
+    uint16_t *buf = (uint16_t *)malloc(count * sizeof(uint16_t));
+    if (!buf)
+        return 1;
+    for (size_t i = 0; i < count; i++)
+        buf[i] = (uint16_t)(i & 0x0FFF);
+
+    Task *tasks = (Task *)calloc(threads, sizeof(Task));
+    if (!tasks)
+        return 1;
+    for (int t = 0; t < threads; t++)
+    {
+        tasks[t].src = buf;
+        tasks[t].width = width;
+        tasks[t].height = height;
+        tasks[t].loops = loops;
+        _TIFFThreadPoolSubmit(bench_task, &tasks[t]);
+    }
+
+    struct timespec s, e;
+    clock_gettime(CLOCK_MONOTONIC, &s);
+    _TIFFThreadPoolWait();
+    clock_gettime(CLOCK_MONOTONIC, &e);
+
+    printf("predictor+pack with %d threads (%zu loops each): %.2f ms\n",
+           threads, loops, elapsed_ms(&s, &e));
+
+    free(tasks);
+    free(buf);
+    _TIFFThreadPoolShutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add predictor_threadpool_benchmark and pack_uring_benchmark utilities
- hook new programs into automake and CMake builds
- document how to run these benchmarks on Pi 5

## Testing
- `pre-commit run --files README.md test/CMakeLists.txt test/Makefile.am test/pack_uring_benchmark.c test/predictor_threadpool_benchmark.c`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6e00e6fc8321930e37b8e29a9587