### PR TITLE
Harden shell scripts

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 
 retval=0
 
@@ -13,11 +14,11 @@ autoreconf --install --force || retval=$?
 for file in config.guess config.sub
 do
     echo "$0: getting $file..."
-    wget --timeout=5 -O config/$file.tmp \
+    wget --timeout=5 -O "config/$file.tmp" \
       "https://git.savannah.gnu.org/cgit/config.git/plain/${file}" \
-      && mv -f config/$file.tmp config/$file \
-      && chmod a+x config/$file
-    rm -f config/$file.tmp
+      && mv -f "config/$file.tmp" "config/$file" \
+      && chmod a+x "config/$file"
+    rm -f "config/$file.tmp"
 done
 
 exit $retval

--- a/contrib/oss-fuzz/build.sh
+++ b/contrib/oss-fuzz/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/bin/bash
+set -euo pipefail
 # Copyright (c) 1988-1997 Sam Leffler
 # Copyright (c) 1991-1997 Silicon Graphics, Inc.
 #
@@ -30,7 +31,7 @@ popd
 
 # Build libjpeg-turbo
 pushd "$SRC/libjpeg-turbo"
-cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DENABLE_STATIC=on -DENABLE_SHARED=off
+cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DENABLE_STATIC=on -DENABLE_SHARED=off
 make -j$(nproc)
 make install
 popd
@@ -41,7 +42,7 @@ if [ "$ARCHITECTURE" = "i386" ]; then
     echo "#!/bin/bash" > gcc
     echo "clang -m32 \$*" >> gcc
     chmod +x gcc
-    PATH=$PWD:$PATH make lib
+    PATH="$PWD:$PATH" make lib
 else
     make lib
 fi
@@ -54,20 +55,20 @@ if [ "$ARCHITECTURE" != "i386" ]; then
     apt-get install -y liblzma-dev
 fi
 
-cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DBUILD_SHARED_LIBS=off
+cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DBUILD_SHARED_LIBS=off
 make -j$(nproc)
 make install
 
 if [ "$ARCHITECTURE" = "i386" ]; then
-    $CXX $CXXFLAGS -std=c++11 -I$WORK/include \
-        $SRC/libtiff/contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc -o $OUT/tiff_read_rgba_fuzzer \
-        $LIB_FUZZING_ENGINE $WORK/lib/libtiffxx.a $WORK/lib/libtiff.a $WORK/lib/libz.a $WORK/lib/libjpeg.a \
-        $WORK/lib/libjbig.a $WORK/lib/libjbig85.a
+    "$CXX" $CXXFLAGS -std=c++11 -I"$WORK/include" \
+        "$SRC/libtiff/contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc" -o "$OUT/tiff_read_rgba_fuzzer" \
+        "$LIB_FUZZING_ENGINE" "$WORK/lib/libtiffxx.a" "$WORK/lib/libtiff.a" "$WORK/lib/libz.a" "$WORK/lib/libjpeg.a" \
+        "$WORK/lib/libjbig.a" "$WORK/lib/libjbig85.a"
 else
-    $CXX $CXXFLAGS -std=c++11 -I$WORK/include \
-        $SRC/libtiff/contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc -o $OUT/tiff_read_rgba_fuzzer \
-        $LIB_FUZZING_ENGINE $WORK/lib/libtiffxx.a $WORK/lib/libtiff.a $WORK/lib/libz.a $WORK/lib/libjpeg.a \
-        $WORK/lib/libjbig.a $WORK/lib/libjbig85.a -Wl,-Bstatic -llzma -Wl,-Bdynamic
+    "$CXX" $CXXFLAGS -std=c++11 -I"$WORK/include" \
+        "$SRC/libtiff/contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc" -o "$OUT/tiff_read_rgba_fuzzer" \
+        "$LIB_FUZZING_ENGINE" "$WORK/lib/libtiffxx.a" "$WORK/lib/libtiff.a" "$WORK/lib/libz.a" "$WORK/lib/libjpeg.a" \
+        "$WORK/lib/libjbig.a" "$WORK/lib/libjbig85.a" -Wl,-Bstatic -llzma -Wl,-Bdynamic
 fi
 
 mkdir afl_testcases

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,11 +1,12 @@
 # Common code fragment for tests
+set -euo pipefail
 #
 srcdir=${srcdir:-.}
-BUILDDIR=`pwd`
-SRCDIR=`dirname $0`
-SRCDIR=`cd $SRCDIR && pwd`
-TOPSRCDIR=`cd $srcdir/.. && pwd`
-TOOLS=`cd ../tools && pwd`
+BUILDDIR=$(pwd)
+SRCDIR=$(dirname "$0")
+SRCDIR=$(cd "$SRCDIR" && pwd)
+TOPSRCDIR=$(cd "$srcdir/.." && pwd)
+TOOLS=$(cd ../tools && pwd)
 IMAGES="${SRCDIR}/images"
 REFS="${SRCDIR}/refs"
 
@@ -62,11 +63,11 @@ f_test_convert ()
   command=$1
   infile=$2
   outfile=$3
-  rm -f $outfile
+  rm -f "$outfile"
   echo "$MEMCHECK $command $infile $outfile"
-  eval $MEMCHECK $command $infile $outfile
+  eval $MEMCHECK $command "$infile" "$outfile"
   status=$?
-  if [ $status != 0 ] ; then
+  if [ "$status" != 0 ] ; then
     echo "Returned failed status $status!"
     echo "Output (if any) is in \"${outfile}\"."
     exit $status
@@ -82,11 +83,11 @@ f_test_stdout ()
   command=$1
   infile=$2
   outfile=$3
-  rm -f $outfile
+  rm -f "$outfile"
   echo "$MEMCHECK $command $infile > $outfile"
-  eval $MEMCHECK $command $infile > $outfile
+  eval $MEMCHECK $command "$infile" > "$outfile"
   status=$?
-  if [ $status != 0 ] ; then
+  if [ "$status" != 0 ] ; then
     echo "Returned failed status $status!"
     echo "Output (if any) is in \"${outfile}\"."
     exit $status
@@ -102,9 +103,9 @@ f_test_reader ()
   command=$1
   infile=$2
   echo "$MEMCHECK $command $infile"
-  eval $MEMCHECK $command $infile
+  eval $MEMCHECK $command "$infile"
   status=$?
-  if [ $status != 0 ] ; then
+  if [ "$status" != 0 ] ; then
     echo "Returned failed status $status!"
     exit $status
   fi
@@ -116,7 +117,7 @@ f_test_reader ()
 # f_tiffinfo_validate infile
 f_tiffinfo_validate ()
 {
-    f_test_reader "$TIFFINFO -D" $1
+    f_test_reader "$TIFFINFO -D" "$1"
 }
 
 if test "$VERBOSE" = TRUE

--- a/test/fax2tiff.sh
+++ b/test/fax2tiff.sh
@@ -1,17 +1,18 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for fax2tiff
 #
 . ${srcdir:-.}/common.sh
 infile="${IMAGES}/miniswhite-1c-1b.g3"
 outfile="o-fax2tiff.tiff"
-rm -f $outfile
-echo "$MEMCHECK ${FAX2TIFF} -M -o $outfile $infile"
-eval $MEMCHECK ${FAX2TIFF} -M -o $outfile $infile
+rm -f "$outfile"
+echo "$MEMCHECK ${FAX2TIFF} -M -o "$outfile" "$infile""
+eval $MEMCHECK ${FAX2TIFF} -M -o "$outfile" "$infile"
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-f_tiffinfo_validate $outfile
+f_tiffinfo_validate "$outfile"

--- a/test/ppm2tiff_pbm.sh
+++ b/test/ppm2tiff_pbm.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 . ${srcdir:-.}/common.sh
 infile="$IMG_MINISWHITE_1C_1B_PBM"
 outfile="o-ppm2tiff_pbm.tiff"
-f_test_convert "$PPM2TIFF" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$PPM2TIFF" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/ppm2tiff_pgm.sh
+++ b/test/ppm2tiff_pgm.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 . ${srcdir:-.}/common.sh
 infile="$IMG_MINISBLACK_1C_8B_PGM"
 outfile="o-ppm2tiff_pgm.tiff"
-f_test_convert "$PPM2TIFF" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$PPM2TIFF" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/ppm2tiff_ppm.sh
+++ b/test/ppm2tiff_ppm.sh
@@ -1,10 +1,11 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 . ${srcdir:-.}/common.sh
 infile="$IMG_RGB_3C_8B_PPM"
 outfile="o-ppm2tiff_8b_ppm.tiff"
-f_test_convert "$PPM2TIFF" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$PPM2TIFF" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"
 infile="$IMG_RGB_3C_16B_PPM"
 outfile="o-ppm2tiff_16b_ppm.tiff"
-f_test_convert "$PPM2TIFF" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$PPM2TIFF" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/testdeflatelaststripextradata.sh
+++ b/test/testdeflatelaststripextradata.sh
@@ -1,42 +1,43 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # check decoding of a deflate compressed file whose last strip which should
 # contain data for only 4 lines has more in it.
 . ${srcdir:-.}/common.sh
 infile="${IMAGES}/deflate-last-strip-extra-data.tiff"
 outfile="o-deflate-last-strip-extra-data.tiff"
-rm -f $outfile
-echo "$MEMCHECK ${TIFFCP} -c zip $infile $outfile"
-eval "$MEMCHECK ${TIFFCP} -c zip $infile $outfile"
+rm -f "$outfile"
+echo "$MEMCHECK ${TIFFCP} -c zip "$infile" "$outfile""
+eval "$MEMCHECK ${TIFFCP} -c zip "$infile" "$outfile""
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/$outfile"
-eval "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/$outfile"
+echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
+eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "\"${outfile}\" differs from reference file."
   exit $status
 fi
 
 outfile="o-deflate-last-strip-extra-data-tiled.tiff"
-rm -f $outfile
-echo "$MEMCHECK ${TIFFCP} -c zip -t -w 256 -l 256 $infile $outfile"
-eval "$MEMCHECK ${TIFFCP} -c zip -t -w 256 -l 256 $infile $outfile"
+rm -f "$outfile"
+echo "$MEMCHECK ${TIFFCP} -c zip -t -w 256 -l 256 "$infile" "$outfile""
+eval "$MEMCHECK ${TIFFCP} -c zip -t -w 256 -l 256 "$infile" "$outfile""
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/o-deflate-last-strip-extra-data.tiff"
-eval "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/o-deflate-last-strip-extra-data.tiff"
+echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/o-deflate-last-strip-extra-data.tiff"
+eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/o-deflate-last-strip-extra-data.tiff"
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "\"${outfile}\" differs from reference file."
   exit $status

--- a/test/testfax3_bug_513.sh
+++ b/test/testfax3_bug_513.sh
@@ -1,23 +1,24 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # check decoding of a CCITT Group 3 encoded TIFF
 # hitting https://gitlab.com/libtiff/libtiff/-/issues/513
 . ${srcdir:-.}/common.sh
 infile="${IMAGES}/testfax3_bug_513.tiff"
 outfile="o-testfax3_bug_513.tiff"
-rm -f $outfile
-echo "$MEMCHECK ${TIFFCP} -c none $infile $outfile"
-eval "$MEMCHECK ${TIFFCP} -c none $infile $outfile"
+rm -f "$outfile"
+echo "$MEMCHECK ${TIFFCP} -c none "$infile" "$outfile""
+eval "$MEMCHECK ${TIFFCP} -c none "$infile" "$outfile""
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/$outfile"
-eval "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/$outfile"
+echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
+eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "\"${outfile}\" differs from reference file."
   exit $status

--- a/test/testfax4.sh
+++ b/test/testfax4.sh
@@ -1,23 +1,24 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # check decoding of a CCITT Group 4 encoded TIFF
 # with 0 length runs
 . ${srcdir:-.}/common.sh
 infile="${IMAGES}/testfax4.tiff"
 outfile="o-testfax4.tiff"
-rm -f $outfile
-echo "$MEMCHECK ${TIFFCP} -c lzw $infile $outfile"
-eval "$MEMCHECK ${TIFFCP} -c lzw $infile $outfile"
+rm -f "$outfile"
+echo "$MEMCHECK ${TIFFCP} -c lzw "$infile" "$outfile""
+eval "$MEMCHECK ${TIFFCP} -c lzw "$infile" "$outfile""
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/$outfile"
-eval "$MEMCHECK ${TIFFCMP} $outfile ${REFS}/$outfile"
+echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
+eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
 status=$?
-if [ $status != 0 ] ; then
+if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "\"${outfile}\" differs from reference file."
   exit $status

--- a/test/tiff2bw-logluv-3c-16b.sh
+++ b/test/tiff2bw-logluv-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/logluv-3c-16b.tiff"
 outfile="o-tiff2bw-logluv-3c-16b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-lzw-single-strip.sh
+++ b/test/tiff2bw-lzw-single-strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/lzw-single-strip.tiff"
 outfile="o-tiff2bw-lzw-single-strip.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-minisblack-1c-16b.sh
+++ b/test/tiff2bw-minisblack-1c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-16b.tiff"
 outfile="o-tiff2bw-minisblack-1c-16b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-minisblack-1c-8b.sh
+++ b/test/tiff2bw-minisblack-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-8b.tiff"
 outfile="o-tiff2bw-minisblack-1c-8b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-minisblack-2c-8b-alpha.sh
+++ b/test/tiff2bw-minisblack-2c-8b-alpha.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-2c-8b-alpha.tiff"
 outfile="o-tiff2bw-minisblack-2c-8b-alpha.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-miniswhite-1c-1b.sh
+++ b/test/tiff2bw-miniswhite-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/miniswhite-1c-1b.tiff"
 outfile="o-tiff2bw-miniswhite-1c-1b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-ojpeg_chewey_subsamp21_multi_strip.sh
+++ b/test/tiff2bw-ojpeg_chewey_subsamp21_multi_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_chewey_subsamp21_multi_strip.tiff"
 outfile="o-tiff2bw-ojpeg_chewey_subsamp21_multi_strip.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-ojpeg_zackthecat_subsamp22_single_strip.sh
+++ b/test/tiff2bw-ojpeg_zackthecat_subsamp22_single_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_zackthecat_subsamp22_single_strip.tiff"
 outfile="o-tiff2bw-ojpeg_zackthecat_subsamp22_single_strip.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-palette-1c-1b.sh
+++ b/test/tiff2bw-palette-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-1b.tiff"
 outfile="o-tiff2bw-palette-1c-1b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-palette-1c-4b.sh
+++ b/test/tiff2bw-palette-1c-4b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-4b.tiff"
 outfile="o-tiff2bw-palette-1c-4b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-palette-1c-8b.sh
+++ b/test/tiff2bw-palette-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-8b.tiff"
 outfile="o-tiff2bw-palette-1c-8b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-quad-lzw-compat.sh
+++ b/test/tiff2bw-quad-lzw-compat.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-lzw-compat.tiff"
 outfile="o-tiff2bw-quad-lzw-compat.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-quad-tile.jpg.sh
+++ b/test/tiff2bw-quad-tile.jpg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.tiff"
 outfile="o-tiff2bw-quad-tile.jpg.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-quad-tile.jpg.t1iff.sh
+++ b/test/tiff2bw-quad-tile.jpg.t1iff.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.t1iff"
 outfile="o-tiff2bw-quad-tile.jpg.t1iff.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-rgb-3c-16b.sh
+++ b/test/tiff2bw-rgb-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-16b.tiff"
 outfile="o-tiff2bw-rgb-3c-16b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2bw-rgb-3c-8b.sh
+++ b/test/tiff2bw-rgb-3c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-8b.tiff"
 outfile="o-tiff2bw-rgb-3c-8b.tiff"
-f_test_convert "$TIFF2BW" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2BW" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2pdf.sh
+++ b/test/tiff2pdf.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiff2pdf
 #

--- a/test/tiff2ps-EPS1.sh
+++ b/test/tiff2ps-EPS1.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffps with PostScript Level 1 encapsulated output
 #

--- a/test/tiff2ps-PS1.sh
+++ b/test/tiff2ps-PS1.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffps with PostScript Level 1 output
 #

--- a/test/tiff2ps-PS2.sh
+++ b/test/tiff2ps-PS2.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffps with PostScript Level 2 output
 #

--- a/test/tiff2ps-PS3.sh
+++ b/test/tiff2ps-PS3.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffps with PostScript Level 3 output
 #

--- a/test/tiff2rgba-32bpp-None-jpeg.sh
+++ b/test/tiff2rgba-32bpp-None-jpeg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/32bpp-None.tiff"
 outfile="o-tiff2rgba-32bpp-None-jpeg.tiff"
-f_test_convert "${TIFF2RGBA} -B 255 -n" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "${TIFF2RGBA} -B 255 -n" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-logluv-3c-16b.sh
+++ b/test/tiff2rgba-logluv-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/logluv-3c-16b.tiff"
 outfile="o-tiff2rgba-logluv-3c-16b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-lzw-single-strip.sh
+++ b/test/tiff2rgba-lzw-single-strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/lzw-single-strip.tiff"
 outfile="o-tiff2rgba-lzw-single-strip.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-minisblack-1c-16b.sh
+++ b/test/tiff2rgba-minisblack-1c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-16b.tiff"
 outfile="o-tiff2rgba-minisblack-1c-16b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-minisblack-1c-8b.sh
+++ b/test/tiff2rgba-minisblack-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-8b.tiff"
 outfile="o-tiff2rgba-minisblack-1c-8b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-minisblack-2c-8b-alpha.sh
+++ b/test/tiff2rgba-minisblack-2c-8b-alpha.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-2c-8b-alpha.tiff"
 outfile="o-tiff2rgba-minisblack-2c-8b-alpha.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-miniswhite-1c-1b.sh
+++ b/test/tiff2rgba-miniswhite-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/miniswhite-1c-1b.tiff"
 outfile="o-tiff2rgba-miniswhite-1c-1b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-ojpeg_chewey_subsamp21_multi_strip.sh
+++ b/test/tiff2rgba-ojpeg_chewey_subsamp21_multi_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_chewey_subsamp21_multi_strip.tiff"
 outfile="o-tiff2rgba-ojpeg_chewey_subsamp21_multi_strip.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-ojpeg_single_strip_no_rowsperstrip.sh
+++ b/test/tiff2rgba-ojpeg_single_strip_no_rowsperstrip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_single_strip_no_rowsperstrip.tiff"
 outfile="o-tiff2rgba-ojpeg_single_strip_no_rowsperstrip.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-ojpeg_zackthecat_subsamp22_single_strip.sh
+++ b/test/tiff2rgba-ojpeg_zackthecat_subsamp22_single_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_zackthecat_subsamp22_single_strip.tiff"
 outfile="o-tiff2rgba-ojpeg_zackthecat_subsamp22_single_strip.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-palette-1c-1b.sh
+++ b/test/tiff2rgba-palette-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-1b.tiff"
 outfile="o-tiff2rgba-palette-1c-1b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-palette-1c-4b.sh
+++ b/test/tiff2rgba-palette-1c-4b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-4b.tiff"
 outfile="o-tiff2rgba-palette-1c-4b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-palette-1c-8b.sh
+++ b/test/tiff2rgba-palette-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-8b.tiff"
 outfile="o-tiff2rgba-palette-1c-8b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-quad-lzw-compat.sh
+++ b/test/tiff2rgba-quad-lzw-compat.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-lzw-compat.tiff"
 outfile="o-tiff2rgba-quad-lzw-compat.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-quad-tile.jpg.sh
+++ b/test/tiff2rgba-quad-tile.jpg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.tiff"
 outfile="o-tiff2rgba-quad-tile.jpg.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-quad-tile.jpg.t1iff.sh
+++ b/test/tiff2rgba-quad-tile.jpg.t1iff.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.t1iff"
 outfile="o-tiff2rgba-quad-tile.jpg.t1iff.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-rgb-3c-16b.sh
+++ b/test/tiff2rgba-rgb-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-16b.tiff"
 outfile="o-tiff2rgba-rgb-3c-16b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiff2rgba-rgb-3c-8b.sh
+++ b/test/tiff2rgba-rgb-3c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-8b.tiff"
 outfile="o-tiff2rgba-rgb-3c-8b.tiff"
-f_test_convert "$TIFF2RGBA" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFF2RGBA" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcp-32bpp-None-jpeg.sh
+++ b/test/tiffcp-32bpp-None-jpeg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/32bpp-None-jpeg.tiff"
 outfile="o-tiffcp-32bpp-None-jpeg-YCbCr.tiff"
-f_test_convert "${TIFFCP} -c jpeg" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "${TIFFCP} -c jpeg" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcp-g3-1d-fill.sh
+++ b/test/tiffcp-g3-1d-fill.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with G3 compression, 1 dimensional
 # encoding, and zero-filled boundaries.

--- a/test/tiffcp-g3-1d.sh
+++ b/test/tiffcp-g3-1d.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with G3 compression and 1 dimensional encoding.
 #

--- a/test/tiffcp-g3-2d-fill.sh
+++ b/test/tiffcp-g3-2d-fill.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with G3 compression, 2 dimensional
 # encoding, and zero-filled boundaries.

--- a/test/tiffcp-g3-2d.sh
+++ b/test/tiffcp-g3-2d.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with G3 compression and 2 dimensional encoding.
 #

--- a/test/tiffcp-g3.sh
+++ b/test/tiffcp-g3.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with G3 compression
 #

--- a/test/tiffcp-g4.sh
+++ b/test/tiffcp-g4.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with G4 compression
 #

--- a/test/tiffcp-logluv.sh
+++ b/test/tiffcp-logluv.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with logluv compression
 #

--- a/test/tiffcp-lzw-compat.sh
+++ b/test/tiffcp-lzw-compat.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with LZW Old-LZW decompression
 #

--- a/test/tiffcp-lzw-scanline-decode.sh
+++ b/test/tiffcp-lzw-scanline-decode.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp with LZW decompression
 #

--- a/test/tiffcp-lzw-single-strip-jbig.sh
+++ b/test/tiffcp-lzw-single-strip-jbig.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/lzw-single-strip.tiff"
 outfile="o-tiffcp-lzw-single-strip-jbig.tiff"
-f_test_convert "${TIFFCP} -c jbig" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "${TIFFCP} -c jbig" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcp-miniswhite-jpegls.sh
+++ b/test/tiffcp-miniswhite-jpegls.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/miniswhite-1c-1b.tiff"
 outfile="o-tiffcp-miniswhite-jpegls.tiff"
-f_test_convert "${TIFFCP} -c jpegls" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "${TIFFCP} -c jpegls" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"
 

--- a/test/tiffcp-split-join.sh
+++ b/test/tiffcp-split-join.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp + tiffsplit + tiffcp
 #

--- a/test/tiffcp-split.sh
+++ b/test/tiffcp-split.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffcp + tiffsplit
 #

--- a/test/tiffcp-thumbnail.sh
+++ b/test/tiffcp-thumbnail.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for thumbnail
 #

--- a/test/tiffcrop-32bpp-None-jpeg.sh
+++ b/test/tiffcrop-32bpp-None-jpeg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/32bpp-None-jpeg.tiff"
 outfile="o-tiffcrop-32bpp-None-jpeg-YCbCr.tiff"
-f_test_convert "${TIFFCROP} -c jpeg" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "${TIFFCROP} -c jpeg" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-logluv-3c-16b.sh
+++ b/test/tiffcrop-R90-logluv-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/logluv-3c-16b.tiff"
 outfile="o-tiffcrop-R90-logluv-3c-16b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-lzw-single-strip.sh
+++ b/test/tiffcrop-R90-lzw-single-strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/lzw-single-strip.tiff"
 outfile="o-tiffcrop-R90-lzw-single-strip.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-minisblack-1c-16b.sh
+++ b/test/tiffcrop-R90-minisblack-1c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-16b.tiff"
 outfile="o-tiffcrop-R90-minisblack-1c-16b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-minisblack-1c-8b.sh
+++ b/test/tiffcrop-R90-minisblack-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-8b.tiff"
 outfile="o-tiffcrop-R90-minisblack-1c-8b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-minisblack-2c-8b-alpha.sh
+++ b/test/tiffcrop-R90-minisblack-2c-8b-alpha.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-2c-8b-alpha.tiff"
 outfile="o-tiffcrop-R90-minisblack-2c-8b-alpha.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-miniswhite-1c-1b.sh
+++ b/test/tiffcrop-R90-miniswhite-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/miniswhite-1c-1b.tiff"
 outfile="o-tiffcrop-R90-miniswhite-1c-1b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-ojpeg_chewey_subsamp21_multi_strip.sh
+++ b/test/tiffcrop-R90-ojpeg_chewey_subsamp21_multi_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_chewey_subsamp21_multi_strip.tiff"
 outfile="o-tiffcrop-R90-ojpeg_chewey_subsamp21_multi_strip.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-ojpeg_zackthecat_subsamp22_single_strip.sh
+++ b/test/tiffcrop-R90-ojpeg_zackthecat_subsamp22_single_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_zackthecat_subsamp22_single_strip.tiff"
 outfile="o-tiffcrop-R90-ojpeg_zackthecat_subsamp22_single_strip.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-palette-1c-1b.sh
+++ b/test/tiffcrop-R90-palette-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-1b.tiff"
 outfile="o-tiffcrop-R90-palette-1c-1b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-palette-1c-4b.sh
+++ b/test/tiffcrop-R90-palette-1c-4b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-4b.tiff"
 outfile="o-tiffcrop-R90-palette-1c-4b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-palette-1c-8b.sh
+++ b/test/tiffcrop-R90-palette-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-8b.tiff"
 outfile="o-tiffcrop-R90-palette-1c-8b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-quad-lzw-compat.sh
+++ b/test/tiffcrop-R90-quad-lzw-compat.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-lzw-compat.tiff"
 outfile="o-tiffcrop-R90-quad-lzw-compat.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-quad-tile.jpg.sh
+++ b/test/tiffcrop-R90-quad-tile.jpg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.tiff"
 outfile="o-tiffcrop-R90-quad-tile.jpg.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-quad-tile.jpg.t1iff.sh
+++ b/test/tiffcrop-R90-quad-tile.jpg.t1iff.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.t1iff"
 outfile="o-tiffcrop-R90-quad-tile.jpg.t1iff.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-rgb-3c-16b.sh
+++ b/test/tiffcrop-R90-rgb-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-16b.tiff"
 outfile="o-tiffcrop-R90-rgb-3c-16b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-R90-rgb-3c-8b.sh
+++ b/test/tiffcrop-R90-rgb-3c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-8b.tiff"
 outfile="o-tiffcrop-R90-rgb-3c-8b.tiff"
-f_test_convert "$TIFFCROP -R90" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -R90" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-logluv-3c-16b.sh
+++ b/test/tiffcrop-doubleflip-logluv-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/logluv-3c-16b.tiff"
 outfile="o-tiffcrop-doubleflip-logluv-3c-16b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-lzw-single-strip.sh
+++ b/test/tiffcrop-doubleflip-lzw-single-strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/lzw-single-strip.tiff"
 outfile="o-tiffcrop-doubleflip-lzw-single-strip.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-minisblack-1c-16b.sh
+++ b/test/tiffcrop-doubleflip-minisblack-1c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-16b.tiff"
 outfile="o-tiffcrop-doubleflip-minisblack-1c-16b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-minisblack-1c-8b.sh
+++ b/test/tiffcrop-doubleflip-minisblack-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-8b.tiff"
 outfile="o-tiffcrop-doubleflip-minisblack-1c-8b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-minisblack-2c-8b-alpha.sh
+++ b/test/tiffcrop-doubleflip-minisblack-2c-8b-alpha.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-2c-8b-alpha.tiff"
 outfile="o-tiffcrop-doubleflip-minisblack-2c-8b-alpha.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-miniswhite-1c-1b.sh
+++ b/test/tiffcrop-doubleflip-miniswhite-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/miniswhite-1c-1b.tiff"
 outfile="o-tiffcrop-doubleflip-miniswhite-1c-1b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-ojpeg_chewey_subsamp21_multi_strip.sh
+++ b/test/tiffcrop-doubleflip-ojpeg_chewey_subsamp21_multi_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_chewey_subsamp21_multi_strip.tiff"
 outfile="o-tiffcrop-doubleflip-ojpeg_chewey_subsamp21_multi_strip.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-ojpeg_zackthecat_subsamp22_single_strip.sh
+++ b/test/tiffcrop-doubleflip-ojpeg_zackthecat_subsamp22_single_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_zackthecat_subsamp22_single_strip.tiff"
 outfile="o-tiffcrop-doubleflip-ojpeg_zackthecat_subsamp22_single_strip.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-palette-1c-1b.sh
+++ b/test/tiffcrop-doubleflip-palette-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-1b.tiff"
 outfile="o-tiffcrop-doubleflip-palette-1c-1b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-palette-1c-4b.sh
+++ b/test/tiffcrop-doubleflip-palette-1c-4b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-4b.tiff"
 outfile="o-tiffcrop-doubleflip-palette-1c-4b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-palette-1c-8b.sh
+++ b/test/tiffcrop-doubleflip-palette-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-8b.tiff"
 outfile="o-tiffcrop-doubleflip-palette-1c-8b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-quad-lzw-compat.sh
+++ b/test/tiffcrop-doubleflip-quad-lzw-compat.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-lzw-compat.tiff"
 outfile="o-tiffcrop-doubleflip-quad-lzw-compat.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-quad-tile.jpg.sh
+++ b/test/tiffcrop-doubleflip-quad-tile.jpg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.tiff"
 outfile="o-tiffcrop-doubleflip-quad-tile.jpg.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-quad-tile.jpg.t1iff.sh
+++ b/test/tiffcrop-doubleflip-quad-tile.jpg.t1iff.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.t1iff"
 outfile="o-tiffcrop-doubleflip-quad-tile.jpg.t1iff.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-rgb-3c-16b.sh
+++ b/test/tiffcrop-doubleflip-rgb-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-16b.tiff"
 outfile="o-tiffcrop-doubleflip-rgb-3c-16b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-doubleflip-rgb-3c-8b.sh
+++ b/test/tiffcrop-doubleflip-rgb-3c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-8b.tiff"
 outfile="o-tiffcrop-doubleflip-rgb-3c-8b.tiff"
-f_test_convert "$TIFFCROP -F both" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -F both" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-logluv-3c-16b.sh
+++ b/test/tiffcrop-extract-logluv-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/logluv-3c-16b.tiff"
 outfile="o-tiffcrop-extract-logluv-3c-16b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-lzw-single-strip.sh
+++ b/test/tiffcrop-extract-lzw-single-strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/lzw-single-strip.tiff"
 outfile="o-tiffcrop-extract-lzw-single-strip.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-minisblack-1c-16b.sh
+++ b/test/tiffcrop-extract-minisblack-1c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-16b.tiff"
 outfile="o-tiffcrop-extract-minisblack-1c-16b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-minisblack-1c-8b.sh
+++ b/test/tiffcrop-extract-minisblack-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-8b.tiff"
 outfile="o-tiffcrop-extract-minisblack-1c-8b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-minisblack-2c-8b-alpha.sh
+++ b/test/tiffcrop-extract-minisblack-2c-8b-alpha.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-2c-8b-alpha.tiff"
 outfile="o-tiffcrop-extract-minisblack-2c-8b-alpha.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-miniswhite-1c-1b.sh
+++ b/test/tiffcrop-extract-miniswhite-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/miniswhite-1c-1b.tiff"
 outfile="o-tiffcrop-extract-miniswhite-1c-1b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-ojpeg_chewey_subsamp21_multi_strip.sh
+++ b/test/tiffcrop-extract-ojpeg_chewey_subsamp21_multi_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_chewey_subsamp21_multi_strip.tiff"
 outfile="o-tiffcrop-extract-ojpeg_chewey_subsamp21_multi_strip.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-ojpeg_zackthecat_subsamp22_single_strip.sh
+++ b/test/tiffcrop-extract-ojpeg_zackthecat_subsamp22_single_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_zackthecat_subsamp22_single_strip.tiff"
 outfile="o-tiffcrop-extract-ojpeg_zackthecat_subsamp22_single_strip.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-palette-1c-1b.sh
+++ b/test/tiffcrop-extract-palette-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-1b.tiff"
 outfile="o-tiffcrop-extract-palette-1c-1b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-palette-1c-4b.sh
+++ b/test/tiffcrop-extract-palette-1c-4b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-4b.tiff"
 outfile="o-tiffcrop-extract-palette-1c-4b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-palette-1c-8b.sh
+++ b/test/tiffcrop-extract-palette-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-8b.tiff"
 outfile="o-tiffcrop-extract-palette-1c-8b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-quad-lzw-compat.sh
+++ b/test/tiffcrop-extract-quad-lzw-compat.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-lzw-compat.tiff"
 outfile="o-tiffcrop-extract-quad-lzw-compat.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-quad-tile.jpg.sh
+++ b/test/tiffcrop-extract-quad-tile.jpg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.tiff"
 outfile="o-tiffcrop-extract-quad-tile.jpg.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-quad-tile.jpg.t1iff.sh
+++ b/test/tiffcrop-extract-quad-tile.jpg.t1iff.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.t1iff"
 outfile="o-tiffcrop-extract-quad-tile.jpg.t1iff.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-rgb-3c-16b.sh
+++ b/test/tiffcrop-extract-rgb-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-16b.tiff"
 outfile="o-tiffcrop-extract-rgb-3c-16b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extract-rgb-3c-8b.sh
+++ b/test/tiffcrop-extract-rgb-3c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-8b.tiff"
 outfile="o-tiffcrop-extract-rgb-3c-8b.tiff"
-f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -U px -E top -X 60 -Y 60" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-logluv-3c-16b.sh
+++ b/test/tiffcrop-extractz14-logluv-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/logluv-3c-16b.tiff"
 outfile="o-tiffcrop-extractz14-logluv-3c-16b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-lzw-single-strip.sh
+++ b/test/tiffcrop-extractz14-lzw-single-strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/lzw-single-strip.tiff"
 outfile="o-tiffcrop-extractz14-lzw-single-strip.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-minisblack-1c-16b.sh
+++ b/test/tiffcrop-extractz14-minisblack-1c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-16b.tiff"
 outfile="o-tiffcrop-extractz14-minisblack-1c-16b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-minisblack-1c-8b.sh
+++ b/test/tiffcrop-extractz14-minisblack-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-1c-8b.tiff"
 outfile="o-tiffcrop-extractz14-minisblack-1c-8b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-minisblack-2c-8b-alpha.sh
+++ b/test/tiffcrop-extractz14-minisblack-2c-8b-alpha.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/minisblack-2c-8b-alpha.tiff"
 outfile="o-tiffcrop-extractz14-minisblack-2c-8b-alpha.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-miniswhite-1c-1b.sh
+++ b/test/tiffcrop-extractz14-miniswhite-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/miniswhite-1c-1b.tiff"
 outfile="o-tiffcrop-extractz14-miniswhite-1c-1b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-ojpeg_chewey_subsamp21_multi_strip.sh
+++ b/test/tiffcrop-extractz14-ojpeg_chewey_subsamp21_multi_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_chewey_subsamp21_multi_strip.tiff"
 outfile="o-tiffcrop-extractz14-ojpeg_chewey_subsamp21_multi_strip.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-ojpeg_zackthecat_subsamp22_single_strip.sh
+++ b/test/tiffcrop-extractz14-ojpeg_zackthecat_subsamp22_single_strip.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/ojpeg_zackthecat_subsamp22_single_strip.tiff"
 outfile="o-tiffcrop-extractz14-ojpeg_zackthecat_subsamp22_single_strip.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-palette-1c-1b.sh
+++ b/test/tiffcrop-extractz14-palette-1c-1b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-1b.tiff"
 outfile="o-tiffcrop-extractz14-palette-1c-1b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-palette-1c-4b.sh
+++ b/test/tiffcrop-extractz14-palette-1c-4b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-4b.tiff"
 outfile="o-tiffcrop-extractz14-palette-1c-4b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-palette-1c-8b.sh
+++ b/test/tiffcrop-extractz14-palette-1c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/palette-1c-8b.tiff"
 outfile="o-tiffcrop-extractz14-palette-1c-8b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-quad-lzw-compat.sh
+++ b/test/tiffcrop-extractz14-quad-lzw-compat.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-lzw-compat.tiff"
 outfile="o-tiffcrop-extractz14-quad-lzw-compat.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-quad-tile.jpg.sh
+++ b/test/tiffcrop-extractz14-quad-tile.jpg.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.tiff"
 outfile="o-tiffcrop-extractz14-quad-tile.jpg.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-quad-tile.jpg.t1iff.sh
+++ b/test/tiffcrop-extractz14-quad-tile.jpg.t1iff.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/quad-tile.jpg.t1iff"
 outfile="o-tiffcrop-extractz14-quad-tile.jpg.t1iff.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-rgb-3c-16b.sh
+++ b/test/tiffcrop-extractz14-rgb-3c-16b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-16b.tiff"
 outfile="o-tiffcrop-extractz14-rgb-3c-16b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffcrop-extractz14-rgb-3c-8b.sh
+++ b/test/tiffcrop-extractz14-rgb-3c-8b.sh
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 # Generated file, master is Makefile.am
 . ${srcdir:-.}/common.sh
 infile="$srcdir/images/rgb-3c-8b.tiff"
 outfile="o-tiffcrop-extractz14-rgb-3c-8b.tiff"
-f_test_convert "$TIFFCROP -E left -Z1:4,2:4" $infile $outfile
-f_tiffinfo_validate $outfile
+f_test_convert "$TIFFCROP -E left -Z1:4,2:4" "$infile" "$outfile"
+f_tiffinfo_validate "$outfile"

--- a/test/tiffdump.sh
+++ b/test/tiffdump.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffdump
 #

--- a/test/tiffinfo.sh
+++ b/test/tiffinfo.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 #
 # Basic sanity check for tiffinfo.
 #


### PR DESCRIPTION
## Summary
- enable `set -euo pipefail` and switch scripts to bash
- quote variable expansions
- replace legacy backticks

## Testing
- `./autogen.sh`
- `./configure`
- `make -j$(nproc)`
- `make check` *(fails: undefined reference to `_TIFFThreadPoolInit`)*

------
https://chatgpt.com/codex/tasks/task_e_684a7dbce8e4832184cb36a2e5fc6553