### PR TITLE
Use memcheck array invocation in tests

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -10,6 +10,14 @@ TOOLS=$(cd ../tools && pwd)
 IMAGES="${SRCDIR}/images"
 REFS="${SRCDIR}/refs"
 
+# Split MEMCHECK environment variable into an array for safe invocation
+if [ -n "${MEMCHECK-}" ]; then
+  # shellcheck disable=SC2206
+  MEMCHECK=( $MEMCHECK )
+else
+  MEMCHECK=()
+fi
+
 # Aliases for built tools
 FAX2PS=${TOOLS}/fax2ps
 FAX2TIFF=${TOOLS}/fax2tiff
@@ -64,8 +72,8 @@ f_test_convert ()
   infile=$2
   outfile=$3
   rm -f "$outfile"
-  echo "$MEMCHECK $command $infile $outfile"
-  eval $MEMCHECK $command "$infile" "$outfile"
+  echo "${MEMCHECK[@]} $command $infile $outfile"
+  "${MEMCHECK[@]}" "$command" "$infile" "$outfile"
   status=$?
   if [ "$status" != 0 ] ; then
     echo "Returned failed status $status!"
@@ -84,8 +92,8 @@ f_test_stdout ()
   infile=$2
   outfile=$3
   rm -f "$outfile"
-  echo "$MEMCHECK $command $infile > $outfile"
-  eval $MEMCHECK $command "$infile" > "$outfile"
+  echo "${MEMCHECK[@]} $command $infile > $outfile"
+  "${MEMCHECK[@]}" "$command" "$infile" > "$outfile"
   status=$?
   if [ "$status" != 0 ] ; then
     echo "Returned failed status $status!"
@@ -102,8 +110,8 @@ f_test_reader ()
 { 
   command=$1
   infile=$2
-  echo "$MEMCHECK $command $infile"
-  eval $MEMCHECK $command "$infile"
+  echo "${MEMCHECK[@]} $command $infile"
+  "${MEMCHECK[@]}" "$command" "$infile"
   status=$?
   if [ "$status" != 0 ] ; then
     echo "Returned failed status $status!"

--- a/test/fax2tiff.sh
+++ b/test/fax2tiff.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 infile="${IMAGES}/miniswhite-1c-1b.g3"
 outfile="o-fax2tiff.tiff"
 rm -f "$outfile"
-echo "$MEMCHECK ${FAX2TIFF} -M -o "$outfile" "$infile""
-eval $MEMCHECK ${FAX2TIFF} -M -o "$outfile" "$infile"
+echo "${MEMCHECK[@]} ${FAX2TIFF} -M -o $outfile $infile"
+"${MEMCHECK[@]}" "${FAX2TIFF}" -M -o "$outfile" "$infile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"

--- a/test/testdeflatelaststripextradata.sh
+++ b/test/testdeflatelaststripextradata.sh
@@ -7,16 +7,16 @@ set -euo pipefail
 infile="${IMAGES}/deflate-last-strip-extra-data.tiff"
 outfile="o-deflate-last-strip-extra-data.tiff"
 rm -f "$outfile"
-echo "$MEMCHECK ${TIFFCP} -c zip "$infile" "$outfile""
-eval "$MEMCHECK ${TIFFCP} -c zip "$infile" "$outfile""
+echo "${MEMCHECK[@]} ${TIFFCP} -c zip $infile $outfile"
+"${MEMCHECK[@]}" "${TIFFCP}" -c zip "$infile" "$outfile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
-eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
+echo "${MEMCHECK[@]} ${TIFFCMP} $outfile ${REFS}/$outfile"
+"${MEMCHECK[@]}" "${TIFFCMP}" "$outfile" "${REFS}/$outfile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
@@ -26,16 +26,16 @@ fi
 
 outfile="o-deflate-last-strip-extra-data-tiled.tiff"
 rm -f "$outfile"
-echo "$MEMCHECK ${TIFFCP} -c zip -t -w 256 -l 256 "$infile" "$outfile""
-eval "$MEMCHECK ${TIFFCP} -c zip -t -w 256 -l 256 "$infile" "$outfile""
+echo "${MEMCHECK[@]} ${TIFFCP} -c zip -t -w 256 -l 256 $infile $outfile"
+"${MEMCHECK[@]}" "${TIFFCP}" -c zip -t -w 256 -l 256 "$infile" "$outfile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/o-deflate-last-strip-extra-data.tiff"
-eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/o-deflate-last-strip-extra-data.tiff"
+echo "${MEMCHECK[@]} ${TIFFCMP} $outfile ${REFS}/o-deflate-last-strip-extra-data.tiff"
+"${MEMCHECK[@]}" "${TIFFCMP}" "$outfile" "${REFS}/o-deflate-last-strip-extra-data.tiff"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"

--- a/test/testfax3_bug_513.sh
+++ b/test/testfax3_bug_513.sh
@@ -7,16 +7,16 @@ set -euo pipefail
 infile="${IMAGES}/testfax3_bug_513.tiff"
 outfile="o-testfax3_bug_513.tiff"
 rm -f "$outfile"
-echo "$MEMCHECK ${TIFFCP} -c none "$infile" "$outfile""
-eval "$MEMCHECK ${TIFFCP} -c none "$infile" "$outfile""
+echo "${MEMCHECK[@]} ${TIFFCP} -c none $infile $outfile"
+"${MEMCHECK[@]}" "${TIFFCP}" -c none "$infile" "$outfile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
-eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
+echo "${MEMCHECK[@]} ${TIFFCMP} $outfile ${REFS}/$outfile"
+"${MEMCHECK[@]}" "${TIFFCMP}" "$outfile" "${REFS}/$outfile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"

--- a/test/testfax4.sh
+++ b/test/testfax4.sh
@@ -7,16 +7,16 @@ set -euo pipefail
 infile="${IMAGES}/testfax4.tiff"
 outfile="o-testfax4.tiff"
 rm -f "$outfile"
-echo "$MEMCHECK ${TIFFCP} -c lzw "$infile" "$outfile""
-eval "$MEMCHECK ${TIFFCP} -c lzw "$infile" "$outfile""
+echo "${MEMCHECK[@]} ${TIFFCP} -c lzw $infile $outfile"
+"${MEMCHECK[@]}" "${TIFFCP}" -c lzw "$infile" "$outfile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"
   echo "Output (if any) is in \"${outfile}\"."
   exit $status
 fi
-echo "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
-eval "$MEMCHECK ${TIFFCMP} "$outfile" ${REFS}/$outfile"
+echo "${MEMCHECK[@]} ${TIFFCMP} $outfile ${REFS}/$outfile"
+"${MEMCHECK[@]}" "${TIFFCMP}" "$outfile" "${REFS}/$outfile"
 status=$?
 if [ "$status" != 0 ] ; then
   echo "Returned failed status $status!"


### PR DESCRIPTION
## Summary
- avoid `eval` when running tests under memcheck
- store MEMCHECK settings as an array in `common.sh`
- update fax2tiff and fax regression tests to use the array

## Testing
- `for f in test/*.sh; do bash -n "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_684a97c4d0788321836657dc76417adf