### PR TITLE
Fix OOM handling in NEON strip helper

### DIFF
--- a/libtiff/tif_strip_neon.c
+++ b/libtiff/tif_strip_neon.c
@@ -38,10 +38,14 @@ uint8_t *TIFFAssembleStripNEON(TIFF *tif, const uint16_t *src, uint32_t width,
                                uint32_t height, int apply_predictor,
                                int bigendian, size_t *out_size)
 {
+    static const char module[] = "TIFFAssembleStripNEON";
     size_t count = (size_t)width * height;
     uint16_t *tmp = (uint16_t *)_TIFFmallocExt(tif, count * sizeof(uint16_t));
     if (!tmp)
+    {
+        TIFFErrorExtR(tif, module, "Out of memory");
         return NULL;
+    }
     memcpy(tmp, src, count * sizeof(uint16_t));
     if (apply_predictor)
     {
@@ -53,6 +57,7 @@ uint8_t *TIFFAssembleStripNEON(TIFF *tif, const uint16_t *src, uint32_t width,
     if (!packed)
     {
         _TIFFfreeExt(tif, tmp);
+        TIFFErrorExtR(tif, module, "Out of memory");
         return NULL;
     }
     TIFFPackRaw12(tmp, packed, count, bigendian);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,6 +249,12 @@ set_target_properties(assemble_strip_neon_test PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(assemble_strip_neon_test PRIVATE tiff tiff_port)
 list(APPEND simple_tests assemble_strip_neon_test)
 
+add_executable(assemble_strip_neon_alloc_fail ../placeholder.h)
+target_sources(assemble_strip_neon_alloc_fail PRIVATE assemble_strip_neon_alloc_fail.c)
+set_target_properties(assemble_strip_neon_alloc_fail PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(assemble_strip_neon_alloc_fail PRIVATE tiff tiff_port failalloc)
+list(APPEND simple_tests assemble_strip_neon_alloc_fail)
+
 add_executable(gray_flip_neon_test ../placeholder.h)
 target_sources(gray_flip_neon_test PRIVATE gray_flip_neon_test.c)
 set_target_properties(gray_flip_neon_test PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -105,7 +105,7 @@ check_PROGRAMS = \
         ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
        defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
        test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
-       threadpool_stress uring_thread_stress threadpool_alloc_fail
+       threadpool_stress uring_thread_stress threadpool_alloc_fail assemble_strip_neon_alloc_fail
 endif
 
 # Test scripts to execute
@@ -322,6 +322,9 @@ swab_neon_test_LDADD = $(LIBTIFF)
 
 assemble_strip_neon_test_SOURCES = assemble_strip_neon_test.c
 assemble_strip_neon_test_LDADD = $(LIBTIFF)
+
+assemble_strip_neon_alloc_fail_SOURCES = assemble_strip_neon_alloc_fail.c failalloc.c
+assemble_strip_neon_alloc_fail_LDADD = $(LIBTIFF)
 
 gray_flip_neon_test_SOURCES = gray_flip_neon_test.c
 gray_flip_neon_test_LDADD = $(LIBTIFF)

--- a/test/assemble_strip_neon_alloc_fail.c
+++ b/test/assemble_strip_neon_alloc_fail.c
@@ -1,0 +1,69 @@
+#include "failalloc.h"
+#include "strip_neon.h"
+#include "tiffio.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char error_buffer[256];
+static char error_module[64];
+
+static void myErrorHandler(thandle_t fd, const char *module, const char *fmt,
+                           va_list ap)
+{
+    (void)fd;
+    vsnprintf(error_buffer, sizeof(error_buffer), fmt, ap);
+    snprintf(error_module, sizeof(error_module), "%s", module);
+}
+
+int main(void)
+{
+    TIFFErrorHandlerExt prev = TIFFSetErrorHandlerExt(myErrorHandler);
+
+    /* Failure of first allocation */
+    setenv("FAIL_MALLOC_COUNT", "1", 1);
+    failalloc_reset_from_env();
+    uint16_t buf[2] = {0, 0};
+    uint8_t *strip = TIFFAssembleStripNEON(NULL, buf, 1, 2, 0, 1, NULL);
+    int ret = 0;
+    if (strip != NULL)
+    {
+        fprintf(stderr, "Expected failure on first allocation\n");
+        free(strip);
+        ret = 1;
+    }
+    if (strcmp(error_buffer, "Out of memory") != 0 ||
+        strcmp(error_module, "TIFFAssembleStripNEON") != 0)
+    {
+        fprintf(stderr, "Unexpected error: %s (%s)\n", error_module,
+                error_buffer);
+        ret = 1;
+    }
+
+    /* Failure of second allocation */
+    setenv("FAIL_MALLOC_COUNT", "2", 1);
+    failalloc_reset_from_env();
+    error_buffer[0] = '\0';
+    error_module[0] = '\0';
+    strip = TIFFAssembleStripNEON(NULL, buf, 1, 2, 0, 1, NULL);
+    if (strip != NULL)
+    {
+        fprintf(stderr, "Expected failure on second allocation\n");
+        free(strip);
+        ret = 1;
+    }
+    if (strcmp(error_buffer, "Out of memory") != 0 ||
+        strcmp(error_module, "TIFFAssembleStripNEON") != 0)
+    {
+        fprintf(stderr, "Unexpected error: %s (%s)\n", error_module,
+                error_buffer);
+        ret = 1;
+    }
+
+    unsetenv("FAIL_MALLOC_COUNT");
+    failalloc_reset_from_env();
+    TIFFSetErrorHandlerExt(prev);
+
+    return ret;
+}


### PR DESCRIPTION
## Summary
- emit `TIFFErrorExtR` when `_TIFFmallocExt` fails in `tif_strip_neon.c`
- add a new test exercising both allocation failure paths
- wire the new test into the build system

## Testing
- `pre-commit run --files libtiff/tif_strip_neon.c test/assemble_strip_neon_alloc_fail.c test/CMakeLists.txt test/Makefile.am`
- `cmake -Dthreadpool=ON -DBUILD_SHARED_LIBS=OFF ..`
- `cmake --build .`
- `ctest` *(fails: pack_uring_benchmark)*

------
https://chatgpt.com/codex/tasks/task_e_684aa6a7024c8321b9252388b3c7bef3