### PR TITLE
Fix overflow in TIFFAssembleStripNEON

### DIFF
--- a/libtiff/tif_strip_neon.c
+++ b/libtiff/tif_strip_neon.c
@@ -39,7 +39,13 @@ uint8_t *TIFFAssembleStripNEON(TIFF *tif, const uint16_t *src, uint32_t width,
                                int bigendian, size_t *out_size)
 {
     static const char module[] = "TIFFAssembleStripNEON";
-    size_t count = (size_t)width * height;
+    uint64_t count64 = _TIFFMultiply64(tif, width, height, module);
+    if (count64 == 0 && width != 0 && height != 0)
+        return NULL;
+    tmsize_t countm = _TIFFCastUInt64ToSSize(tif, count64, module);
+    if (countm == 0 && count64 != 0)
+        return NULL;
+    size_t count = (size_t)countm;
     uint16_t *tmp = (uint16_t *)_TIFFmallocExt(tif, count * sizeof(uint16_t));
     if (!tmp)
     {

--- a/test/assemble_strip_neon_alloc_fail.c
+++ b/test/assemble_strip_neon_alloc_fail.c
@@ -63,6 +63,26 @@ int main(void)
 
     unsetenv("FAIL_MALLOC_COUNT");
     failalloc_reset_from_env();
+
+    /* Overflow detection */
+    error_buffer[0] = '\0';
+    error_module[0] = '\0';
+    strip =
+        TIFFAssembleStripNEON(NULL, buf, 0xFFFFFFFFU, 0xFFFFFFFFU, 0, 1, NULL);
+    if (strip != NULL)
+    {
+        fprintf(stderr, "Expected overflow failure\n");
+        free(strip);
+        ret = 1;
+    }
+    if (strcmp(error_buffer, "Integer overflow in TIFFAssembleStripNEON") != 0 ||
+        strcmp(error_module, "TIFFAssembleStripNEON") != 0)
+    {
+        fprintf(stderr, "Unexpected error: %s (%s)\n", error_module,
+                error_buffer);
+        ret = 1;
+    }
+
     TIFFSetErrorHandlerExt(prev);
 
     return ret;


### PR DESCRIPTION
## Summary
- guard `TIFFAssembleStripNEON` against `width*height` overflow
- test overflow handling in `assemble_strip_neon_alloc_fail`

## Testing
- `cmake --build . -j$(nproc)` *(fails: Returned failed status 1)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa09deb08321b56ad5f8f3f07439