### PR TITLE
Optimize data move using copy_file_range

### DIFF
--- a/libtiff/tiffiop.h
+++ b/libtiff/tiffiop.h
@@ -262,8 +262,8 @@ struct tiff
     tmsize_t tif_max_cumulated_mem_alloc; /* in bytes. 0 for unlimited */
     tmsize_t tif_cur_cumulated_mem_alloc; /* in bytes */
 #ifdef USE_IO_URING
-    struct io_uring *tif_uring; /* persistent io_uring handle */
-    int tif_uring_async;        /* async flush/wait semantics */
+    struct io_uring *tif_uring;   /* persistent io_uring handle */
+    int tif_uring_async;          /* async flush/wait semantics */
     unsigned int tif_uring_depth; /* queue depth. 0 for default */
 #endif
     int tif_warn_about_unknown_tags;
@@ -279,7 +279,7 @@ struct TIFFOpenOptions
     tmsize_t max_cumulated_mem_alloc;  /* in bytes. 0 for unlimited */
     int warn_about_unknown_tags;
 #ifdef USE_IO_URING
-    unsigned int uring_queue_depth;    /* 0 for default */
+    unsigned int uring_queue_depth; /* 0 for default */
 #endif
 };
 
@@ -563,6 +563,9 @@ extern "C"
     extern void _tiffUringFlush(TIFF *tif);
     extern void _tiffUringWait(TIFF *tif);
 #endif
+
+    extern int _TIFFCopyFileRange(TIFF *tif, uint64_t offsetRead,
+                                  uint64_t offsetWrite, uint64_t toCopy);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary
- add `_TIFFCopyFileRange` helper
- use the helper inside `TIFFAppendToStrip`
- fall back to read/write when `copy_file_range` isn't available

## Testing
- `pre-commit run --files libtiff/tiffiop.h libtiff/tif_unix.c libtiff/tif_write.c`
- `ctest --output-on-failure -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684ab7f4d93c8321941cf254d0d163c0