### PR TITLE
Use per-TIFF thread pool

### DIFF
--- a/libtiff/tif_close.c
+++ b/libtiff/tif_close.c
@@ -120,6 +120,13 @@ void TIFFCleanup(TIFF *tif)
                       "should be 0",
                       (uint64_t)tif->tif_cur_cumulated_mem_alloc);
     }
+#ifdef TIFF_USE_THREADPOOL
+    if (tif->tif_threadpool)
+    {
+        _TIFFThreadPoolShutdown(tif->tif_threadpool);
+        tif->tif_threadpool = NULL;
+    }
+#endif
 
     _TIFFfreeExt(NULL, tif);
 }

--- a/libtiff/tif_jpeg.c
+++ b/libtiff/tif_jpeg.c
@@ -1628,11 +1628,11 @@ static int JPEGDecodeInternal(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s)
 static int JPEGDecode(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s)
 {
 #ifdef TIFF_USE_THREADPOOL
-    if (TIFFGetThreadCount() > 1)
+    if (TIFFGetThreadCount(tif) > 1)
     {
         JPEGTask task = {tif, buf, cc, s, 0};
-        _TIFFThreadPoolSubmit(JPEGDecodeTask, &task);
-        _TIFFThreadPoolWait();
+        _TIFFThreadPoolSubmit(tif->tif_threadpool, JPEGDecodeTask, &task);
+        _TIFFThreadPoolWait(tif->tif_threadpool);
         return task.result;
     }
 #endif

--- a/libtiff/tif_zip.c
+++ b/libtiff/tif_zip.c
@@ -335,11 +335,11 @@ static int ZIPDecodeInternal(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 static int ZIPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 {
 #ifdef TIFF_USE_THREADPOOL
-    if (TIFFGetThreadCount() > 1)
+    if (TIFFGetThreadCount(tif) > 1)
     {
         ZIPTask task = {tif, op, occ, s, 0};
-        _TIFFThreadPoolSubmit(ZIPDecodeTask, &task);
-        _TIFFThreadPoolWait();
+        _TIFFThreadPoolSubmit(tif->tif_threadpool, ZIPDecodeTask, &task);
+        _TIFFThreadPoolWait(tif->tif_threadpool);
         return task.result;
     }
 #endif

--- a/libtiff/tiff_threadpool.h
+++ b/libtiff/tiff_threadpool.h
@@ -3,14 +3,16 @@
 
 #include "tiffiop.h"
 
+typedef struct TIFFThreadPool TIFFThreadPool;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int _TIFFThreadPoolInit(int workers);
-void _TIFFThreadPoolShutdown(void);
-int _TIFFThreadPoolSubmit(void (*func)(void*), void* arg);
-void _TIFFThreadPoolWait(void);
+TIFFThreadPool *_TIFFThreadPoolInit(int workers);
+void _TIFFThreadPoolShutdown(TIFFThreadPool *);
+int _TIFFThreadPoolSubmit(TIFFThreadPool *, void (*func)(void*), void* arg);
+void _TIFFThreadPoolWait(TIFFThreadPool *);
 
 #ifdef __cplusplus
 }

--- a/libtiff/tiffio.h
+++ b/libtiff/tiffio.h
@@ -572,8 +572,8 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
     extern uint32_t TIFFNumberOfStrips(TIFF *);
 
     /* Thread pool management */
-    extern void TIFFSetThreadCount(int);
-    extern int TIFFGetThreadCount(void);
+    extern void TIFFSetThreadCount(TIFF *, int);
+    extern int TIFFGetThreadCount(TIFF *);
     extern void TIFFInitSIMD(void);
     extern tmsize_t TIFFReadEncodedStrip(TIFF *tif, uint32_t strip, void *buf,
                                          tmsize_t size);

--- a/libtiff/tiffiop.h
+++ b/libtiff/tiffiop.h
@@ -112,6 +112,8 @@ typedef union
     TIFFHeaderBig big;
 } TIFFHeaderUnion;
 
+struct TIFFThreadPool; /* forward declaration */
+
 struct tiff
 {
     char *tif_name; /* name of open file */
@@ -267,6 +269,7 @@ struct tiff
     unsigned int tif_uring_depth; /* queue depth. 0 for default */
 #endif
     int tif_warn_about_unknown_tags;
+    struct TIFFThreadPool *tif_threadpool; /* thread pool handle */
 };
 
 struct TIFFOpenOptions

--- a/test/predictor_threadpool_benchmark.c
+++ b/test/predictor_threadpool_benchmark.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
     if (argc > 2)
         loops = (size_t)atoi(argv[2]);
 
-    _TIFFThreadPoolInit(threads);
+    TIFFThreadPool *tp = _TIFFThreadPoolInit(threads);
 
     const uint32_t width = 512, height = 512;
     size_t count = (size_t)width * height;
@@ -58,12 +58,12 @@ int main(int argc, char **argv)
         tasks[t].width = width;
         tasks[t].height = height;
         tasks[t].loops = loops;
-        _TIFFThreadPoolSubmit(bench_task, &tasks[t]);
+        _TIFFThreadPoolSubmit(tp, bench_task, &tasks[t]);
     }
 
     struct timespec s, e;
     clock_gettime(CLOCK_MONOTONIC, &s);
-    _TIFFThreadPoolWait();
+    _TIFFThreadPoolWait(tp);
     clock_gettime(CLOCK_MONOTONIC, &e);
 
     printf("predictor+pack with %d threads (%zu loops each): %.2f ms\n",
@@ -71,6 +71,6 @@ int main(int argc, char **argv)
 
     free(tasks);
     free(buf);
-    _TIFFThreadPoolShutdown();
+    _TIFFThreadPoolShutdown(tp);
     return 0;
 }

--- a/test/threadpool_alloc_fail.c
+++ b/test/threadpool_alloc_fail.c
@@ -10,27 +10,33 @@ static void dummy(void* arg) { (void)arg; }
 int main(void)
 {
     int ret = 0;
+    TIFFThreadPool* tp;
     /* calloc failure during init */
     setenv("FAIL_CALLOC_COUNT", "1", 1);
     failalloc_reset_from_env();
-    if (_TIFFThreadPoolInit(2))
+    tp = _TIFFThreadPoolInit(2);
+    if (tp)
     {
         fprintf(stderr, "Expected calloc failure\n");
         ret = 1;
+        _TIFFThreadPoolShutdown(tp);
     }
     /* pthread_create failure */
     setenv("FAIL_PTHREAD_CREATE_COUNT", "1", 1);
     failalloc_reset_from_env();
-    if (_TIFFThreadPoolInit(2))
+    tp = _TIFFThreadPoolInit(2);
+    if (tp)
     {
         fprintf(stderr, "Expected pthread_create failure\n");
         ret = 1;
+        _TIFFThreadPoolShutdown(tp);
     }
     /* successful init */
     unsetenv("FAIL_PTHREAD_CREATE_COUNT");
     unsetenv("FAIL_CALLOC_COUNT");
     failalloc_reset_from_env();
-    if (!_TIFFThreadPoolInit(1))
+    tp = _TIFFThreadPoolInit(1);
+    if (!tp)
     {
         fprintf(stderr, "Expected init success\n");
         ret = 1;
@@ -38,13 +44,13 @@ int main(void)
     /* malloc failure on submit */
     setenv("FAIL_MALLOC_COUNT", "1", 1);
     failalloc_reset_from_env();
-    if (_TIFFThreadPoolSubmit(dummy, NULL))
+    if (_TIFFThreadPoolSubmit(tp, dummy, NULL))
     {
         fprintf(stderr, "Expected submit failure\n");
         ret = 1;
     }
     unsetenv("FAIL_MALLOC_COUNT");
     failalloc_reset_from_env();
-    _TIFFThreadPoolShutdown();
+    _TIFFThreadPoolShutdown(tp);
     return ret;
 }

--- a/test/threadpool_stress.c
+++ b/test/threadpool_stress.c
@@ -7,6 +7,7 @@
 
 static pthread_mutex_t cnt_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int counter = 0;
+static TIFFThreadPool *tp;
 
 static void inc_task(void *arg)
 {
@@ -20,13 +21,13 @@ static void *producer(void *arg)
 {
     (void)arg;
     for (int i = 0; i < TASKS_PER_THREAD; i++)
-        _TIFFThreadPoolSubmit(inc_task, NULL);
+        _TIFFThreadPoolSubmit(tp, inc_task, NULL);
     return NULL;
 }
 
 int main(void)
 {
-    _TIFFThreadPoolInit(PRODUCER_THREADS);
+    tp = _TIFFThreadPoolInit(PRODUCER_THREADS);
 
     pthread_t prod[PRODUCER_THREADS];
     for (int i = 0; i < PRODUCER_THREADS; i++)
@@ -34,8 +35,8 @@ int main(void)
     for (int i = 0; i < PRODUCER_THREADS; i++)
         pthread_join(prod[i], NULL);
 
-    _TIFFThreadPoolWait();
-    _TIFFThreadPoolShutdown();
+    _TIFFThreadPoolWait(tp);
+    _TIFFThreadPoolShutdown(tp);
 
     int expected = PRODUCER_THREADS * TASKS_PER_THREAD;
     if (counter != expected)


### PR DESCRIPTION
## Summary
- refactor internal thread pool API to return a handle
- store the thread pool handle in TIFF
- pass per-file handle to JPEG/ZIP decode routines
- clean up the thread pool in TIFFCleanup
- adapt unit tests for new API

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `ctest --output-on-failure` *(fails: assemble_strip_neon_alloc_fail, predictor_threadpool_benchmark, pack_uring_benchmark, threadpool_stress, threadpool_alloc_fail, grow_strips_alloc_fail)*

------
https://chatgpt.com/codex/tasks/task_e_684ac285d9148321a4295c09251f7876