### PR TITLE
Document DNG tag support

### DIFF
--- a/doc/functions.rst
+++ b/doc/functions.rst
@@ -64,3 +64,18 @@ TIFF Functions Overview
     functions/TIFFWriteTile
     functions/_TIFFauxiliary
     functions/_TIFFRewriteField
+
+Digital Negative (DNG) tags
+--------------------------
+
+``libtiff`` includes built-in definitions for the tags from the Adobe
+Digital Negative (DNG) specification.  The definitions can be found in
+``tif_dirinfo.c`` and cover versions 1.0 through 1.6 of the
+specification, including tags such as ``DNGVersion``, ``DNGBackwardVersion``
+and ``DNGPrivateData``.  Applications can therefore read and write DNG
+files without having to register these tags.
+
+If an application needs to store additional vendor-specific DNG tags it
+may register them using :c:func:`TIFFMergeFieldInfo`.  Projects like
+*CinePi* use this mechanism to attach custom colour pipeline metadata at
+runtime.


### PR DESCRIPTION
## Summary
- mention built-in DNG tag definitions in `tif_dirinfo.c`
- explain how apps such as CinePi register extra tags with `TIFFMergeFieldInfo`

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684ac7f526bc8321bf28dc5a4b2bba10