### PR TITLE
Add checks after _TIFFmallocExt calls

### DIFF
--- a/libtiff/tif_extension.c
+++ b/libtiff/tif_extension.c
@@ -99,10 +99,19 @@ void TIFFSetClientInfo(TIFF *tif, void *data, const char *name)
 
     psLink =
         (TIFFClientInfoLink *)_TIFFmallocExt(tif, sizeof(TIFFClientInfoLink));
-    assert(psLink != NULL);
+    if (psLink == NULL)
+    {
+        TIFFErrorExtR(tif, "TIFFSetClientInfo", "Out of memory");
+        return;
+    }
     psLink->next = tif->tif_clientinfo;
     psLink->name = (char *)_TIFFmallocExt(tif, (tmsize_t)(strlen(name) + 1));
-    assert(psLink->name != NULL);
+    if (psLink->name == NULL)
+    {
+        TIFFErrorExtR(tif, "TIFFSetClientInfo", "Out of memory");
+        _TIFFfreeExt(tif, psLink);
+        return;
+    }
     strcpy(psLink->name, name);
     psLink->data = data;
 

--- a/libtiff/tif_jpeg.c
+++ b/libtiff/tif_jpeg.c
@@ -1554,6 +1554,11 @@ static int JPEGDecodeInternal(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s)
             line_work_buf = (TIFF_JSAMPROW)_TIFFmallocExt(
                 tif, sizeof(short) * sp->cinfo.d.output_width *
                          sp->cinfo.d.num_components);
+            if (line_work_buf == NULL)
+            {
+                TIFFErrorExtR(tif, "JPEGDecodeInternal", "Out of memory");
+                return 0;
+            }
         }
 
         do

--- a/libtiff/tif_print.c
+++ b/libtiff/tif_print.c
@@ -681,6 +681,12 @@ void TIFFPrintDirectory(TIFF *tif, FILE *fd, long flags)
                      */
                     int tv_size = TIFFFieldSetGetSize(fip);
                     raw_data = _TIFFmallocExt(tif, tv_size * value_count);
+                    if (raw_data == NULL)
+                    {
+                        TIFFErrorExtR(tif, "TIFFPrintDirectory",
+                                      "Out of memory");
+                        continue;
+                    }
                     mem_alloc = 1;
                     if (TIFFGetField(tif, tag, raw_data) != 1)
                     {


### PR DESCRIPTION
## Summary
- add OOM checks in TIFFPrintDirectory
- check TIFFSetClientInfo allocations
- validate JPEGDecodeInternal temporary buffer

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)` *(fails: linking threadpool tests)*
- `ctest --output-on-failure` *(fails: several tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684ac9ea07bc832183e9d8d1884c8394