### PR TITLE
Handle threadpool init failures

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -298,6 +298,11 @@ target_sources(threadpool_alloc_fail PRIVATE threadpool_alloc_fail.c)
 target_link_libraries(threadpool_alloc_fail PRIVATE tiff tiff_port failalloc)
 list(APPEND simple_tests threadpool_alloc_fail)
 
+add_executable(threadpool_init_fail ../placeholder.h)
+target_sources(threadpool_init_fail PRIVATE threadpool_init_fail.c)
+target_link_libraries(threadpool_init_fail PRIVATE tiff tiff_port failalloc)
+list(APPEND simple_tests threadpool_init_fail)
+
 add_executable(grow_strips_alloc_fail ../placeholder.h)
 target_sources(grow_strips_alloc_fail PRIVATE grow_strips_alloc_fail.c)
 target_link_libraries(grow_strips_alloc_fail PRIVATE tiff tiff_port failalloc)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -105,7 +105,7 @@ check_PROGRAMS = \
         ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
        defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
        test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
-       threadpool_stress uring_thread_stress threadpool_alloc_fail assemble_strip_neon_alloc_fail
+       threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail
 endif
 
 # Test scripts to execute
@@ -343,6 +343,8 @@ uring_thread_stress_SOURCES = uring_thread_stress.c
 uring_thread_stress_LDADD = $(LIBTIFF)
 threadpool_alloc_fail_SOURCES = threadpool_alloc_fail.c failalloc.c
 threadpool_alloc_fail_LDADD = $(LIBTIFF)
+threadpool_init_fail_SOURCES = threadpool_init_fail.c failalloc.c
+threadpool_init_fail_LDADD = $(LIBTIFF)
 
 AM_CPPFLAGS = -I$(top_srcdir)/libtiff
 

--- a/test/threadpool_init_fail.c
+++ b/test/threadpool_init_fail.c
@@ -1,0 +1,47 @@
+#include "tiff_threadpool.h"
+#include "failalloc.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+    int ret = 0;
+    TIFFThreadPool* tp;
+
+    /* pthread_mutex_init failure */
+    setenv("FAIL_PTHREAD_MUTEX_INIT_COUNT", "1", 1);
+    failalloc_reset_from_env();
+    tp = _TIFFThreadPoolInit(1);
+    if (tp)
+    {
+        fprintf(stderr, "Expected pthread_mutex_init failure\n");
+        ret = 1;
+        _TIFFThreadPoolShutdown(tp);
+    }
+    unsetenv("FAIL_PTHREAD_MUTEX_INIT_COUNT");
+
+    /* pthread_cond_init failure */
+    setenv("FAIL_PTHREAD_COND_INIT_COUNT", "1", 1);
+    failalloc_reset_from_env();
+    tp = _TIFFThreadPoolInit(1);
+    if (tp)
+    {
+        fprintf(stderr, "Expected pthread_cond_init failure\n");
+        ret = 1;
+        _TIFFThreadPoolShutdown(tp);
+    }
+    unsetenv("FAIL_PTHREAD_COND_INIT_COUNT");
+
+    /* successful init */
+    failalloc_reset_from_env();
+    tp = _TIFFThreadPoolInit(1);
+    if (!tp)
+    {
+        fprintf(stderr, "Expected init success\n");
+        ret = 1;
+    }
+    if (tp)
+        _TIFFThreadPoolShutdown(tp);
+
+    return ret;
+}


### PR DESCRIPTION
## Summary
- check pthread init results in `_TIFFThreadPoolInit`
- simulate mutex/cond init failures in failalloc
- add regression test for failing threadpool init

## Testing
- `cmake --build build_dir --target threadpool_init_fail`
- `ctest -R threadpool_init_fail -V`
- `cmake --build build_dir --target threadpool_alloc_fail`
- `ctest -R threadpool_alloc_fail -V`


------
https://chatgpt.com/codex/tasks/task_e_684ad0bc204c8321925b0bac4ce9ed1f