### PR TITLE
Improve open mode validation and memory header checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ typedef uint8x16_t tiff_v16u8;
 A placeholder codec integrates with CharLS when available. Configure with `-Djpegls=ON` or `--with-jpegls` to experiment.
 
 ### Lazy Strile Loading
-`TIFFOpen()` accepts `'D'` (defer) and `'O'` (on‑demand) mode flags.  `'D'`
-postpones loading the `StripOffsets`/`StripByteCounts` or
-`TileOffsets`/`TileByteCounts` arrays until first use.  `'O'` implies `'D'` and
-only fetches the requested strip or tile entry.  These flags enable lazy
-metadata access and can significantly reduce startup time when files reside on
-slow storage.
+`TIFFOpen()` accepts `'D'` (defer) and `'O'` (on‑demand) mode flags. Append
+them to the mode string like `"rD"` or `"rO"`. `'D'` postpones loading the
+`StripOffsets`/`StripByteCounts` or `TileOffsets`/`TileByteCounts` arrays until
+first use. `'O'` implies `'D'` and only fetches the requested strip or tile
+entry. These flags enable lazy metadata access and can significantly reduce
+startup time when files reside on slow storage.
 
 See [doc/functions/TIFFStrileQuery.rst](doc/functions/TIFFStrileQuery.rst) for
 details on querying per‑strile information.


### PR DESCRIPTION
## Summary
- replace compile-time asserts with runtime checks in `tif_open.c`
- validate allocation headers in `_TIFFreallocExt` and `_TIFFfreeExt`
- reject unknown open mode flags in `TIFFClientOpenExt`
- document `D` and `O` mode flags in README

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)` *(fails: undefined references to threadpool functions)*

------
https://chatgpt.com/codex/tasks/task_e_684ad98aaf3083218b9060f47c506898