### PR TITLE
Fix PixarLogSetupEncode tbuf_size error

### DIFF
--- a/libtiff/tif_pixarlog.c
+++ b/libtiff/tif_pixarlog.c
@@ -1012,8 +1012,10 @@ static int PixarLogSetupEncode(TIFF *tif)
                                 td->td_rowsperstrip),
                     sizeof(uint16_t));
     if (tbuf_size == 0)
-        return (0); /* TODO: this is an error return without error report
-                       through TIFFErrorExt */
+    {
+        TIFFErrorExtR(tif, module, "PixarLog tbuf_size overflow");
+        return (0);
+    }
     sp->tbuf = (uint16_t *)_TIFFmallocExt(tif, tbuf_size);
     if (sp->tbuf == NULL)
         return (0);


### PR DESCRIPTION
## Summary
- emit a warning when PixarLogSetupEncode detects `tbuf_size` overflow

## Testing
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(fails: `tiffcrop-extract-lzw-single-strip`, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684d31ef2c548321bc772156ee829ed0