### PR TITLE
Use NEON for overlapping memmoves

### DIFF
--- a/libtiff/tif_getimage.c
+++ b/libtiff/tif_getimage.c
@@ -27,8 +27,8 @@
  *
  * Read and return a packed RGBA image.
  */
-#include "tiffiop.h"
 #include "tiff_simd.h"
+#include "tiffiop.h"
 #include <limits.h>
 #include <stdio.h>
 
@@ -1585,7 +1585,8 @@ DECLAREContigPutFunc(putagreytile)
 #if TIFF_SIMD_NEON
 static void putgreytile_neon(TIFFRGBAImage *img, uint32_t *cp, uint32_t x,
                              uint32_t y, uint32_t w, uint32_t h,
-                             int32_t fromskew, int32_t toskew, unsigned char *pp)
+                             int32_t fromskew, int32_t toskew,
+                             unsigned char *pp)
 {
     int samplesperpixel = img->samplesperpixel;
     int invert = (img->photometric == PHOTOMETRIC_MINISWHITE);
@@ -1620,8 +1621,8 @@ static void putgreytile_neon(TIFFRGBAImage *img, uint32_t *cp, uint32_t x,
             uint8_t v = *pp++;
             if (invert)
                 v = (uint8_t)(255 - v);
-            *cp++ = ((uint32_t)v) | ((uint32_t)v << 8) | ((uint32_t)v << 16) |
-                     A1;
+            *cp++ =
+                ((uint32_t)v) | ((uint32_t)v << 8) | ((uint32_t)v << 16) | A1;
         }
         cp += toskew;
         pp += fromskew;
@@ -1671,7 +1672,7 @@ static void putagreytile_neon(TIFFRGBAImage *img, uint32_t *cp, uint32_t x,
             if (invert)
                 g = (uint8_t)(255 - g);
             *cp++ = ((uint32_t)g) | ((uint32_t)g << 8) | ((uint32_t)g << 16) |
-                     ((uint32_t)a << 24);
+                    ((uint32_t)a << 24);
         }
         cp += toskew;
         pp += fromskew;
@@ -3489,9 +3490,11 @@ int TIFFReadRGBATileExt(TIFF *tif, uint32_t col, uint32_t row, uint32_t *raster,
 
     for (i_row = 0; i_row < read_ysize; i_row++)
     {
-        memmove(raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize,
-                raster + (size_t)(read_ysize - i_row - 1) * read_xsize,
-                read_xsize * sizeof(uint32_t));
+        tiff_memmove_u8(
+            (uint8_t *)(raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize),
+            (const uint8_t *)(raster +
+                              (size_t)(read_ysize - i_row - 1) * read_xsize),
+            read_xsize * sizeof(uint32_t));
         _TIFFmemset(raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize +
                         read_xsize,
                     0, sizeof(uint32_t) * (tile_xsize - read_xsize));

--- a/libtiff/tif_lerc.c
+++ b/libtiff/tif_lerc.c
@@ -22,6 +22,7 @@
  * OF THIS SOFTWARE.
  */
 
+#include "tiff_simd.h"
 #include "tiffiop.h"
 #ifdef LERC_SUPPORT
 /*
@@ -621,8 +622,9 @@ static int LERCPreDecode(TIFF *tif, uint16_t s)
             i--;
             sp->uncompressed_buffer[i * dst_stride + td->td_samplesperpixel -
                                     1] = 255 * sp->mask_buffer[i];
-            memmove(sp->uncompressed_buffer + i * dst_stride,
-                    sp->uncompressed_buffer + i * src_stride, src_stride);
+            tiff_memmove_u8(sp->uncompressed_buffer + i * dst_stride,
+                            sp->uncompressed_buffer + i * src_stride,
+                            src_stride);
         }
     }
     else if (use_mask && td->td_sampleformat == SAMPLEFORMAT_IEEEFP)
@@ -890,8 +892,9 @@ static int LERCPostEncode(TIFF *tif)
             /* First pixels must use memmove due to overlapping areas */
             for (i = 0; i < dst_nbands && i < nb_pixels; i++)
             {
-                memmove(sp->uncompressed_buffer + i * dst_stride,
-                        sp->uncompressed_buffer + i * src_stride, dst_stride);
+                tiff_memmove_u8(sp->uncompressed_buffer + i * dst_stride,
+                                sp->uncompressed_buffer + i * src_stride,
+                                dst_stride);
                 sp->mask_buffer[i] =
                     sp->uncompressed_buffer[i * src_stride +
                                             td->td_samplesperpixel - 1];

--- a/libtiff/tif_read.c
+++ b/libtiff/tif_read.c
@@ -26,6 +26,7 @@
  * TIFF Library.
  * Scanline-oriented Read Support
  */
+#include "tiff_simd.h"
 #include "tiffiop.h"
 #include <stdio.h>
 
@@ -214,7 +215,7 @@ static int TIFFFillStripPartial(TIFF *tif, int strip, tmsize_t read_ahead,
     if (unused_data > 0)
     {
         assert((tif->tif_flags & TIFF_BUFFERMMAP) == 0);
-        memmove(tif->tif_rawdata, tif->tif_rawcp, unused_data);
+        tiff_memmove_u8(tif->tif_rawdata, tif->tif_rawcp, unused_data);
     }
 
     /*

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -261,6 +261,12 @@ set_target_properties(gray_flip_neon_test PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(gray_flip_neon_test PRIVATE tiff tiff_port)
 list(APPEND simple_tests gray_flip_neon_test)
 
+add_executable(memmove_simd_test ../placeholder.h)
+target_sources(memmove_simd_test PRIVATE memmove_simd_test.c)
+set_target_properties(memmove_simd_test PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(memmove_simd_test PRIVATE tiff tiff_port)
+list(APPEND simple_tests memmove_simd_test)
+
 add_executable(swab_benchmark ../placeholder.h)
 target_sources(swab_benchmark PRIVATE swab_benchmark.c)
 set_target_properties(swab_benchmark PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -102,9 +102,9 @@ endif
 # Executable programs which need to be built in order to support tests
 if TIFF_TESTS
 check_PROGRAMS = \
-        ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
+       ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
        defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
-       test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
+       test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test memmove_simd_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
        threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail
 endif
 
@@ -328,6 +328,9 @@ assemble_strip_neon_alloc_fail_LDADD = $(LIBTIFF)
 
 gray_flip_neon_test_SOURCES = gray_flip_neon_test.c
 gray_flip_neon_test_LDADD = $(LIBTIFF)
+
+memmove_simd_test_SOURCES = memmove_simd_test.c
+memmove_simd_test_LDADD = $(LIBTIFF)
 
 swab_benchmark_SOURCES = swab_benchmark.c
 swab_benchmark_LDADD = $(LIBTIFF)

--- a/test/memmove_simd_test.c
+++ b/test/memmove_simd_test.c
@@ -1,0 +1,38 @@
+#include "tiff_simd.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+    const size_t N = 1024;
+    uint8_t *buf1 = (uint8_t *)malloc(N + 32);
+    uint8_t *buf2 = (uint8_t *)malloc(N + 32);
+    uint8_t *buf3 = (uint8_t *)malloc(N + 32);
+    if (!buf1 || !buf2 || !buf3)
+        return 1;
+    for (size_t i = 0; i < N + 32; i++)
+        buf1[i] = (uint8_t)(i & 0xff);
+    memcpy(buf2, buf1, N + 32);
+    memcpy(buf3, buf1, N + 32);
+
+    /* dest < src overlap */
+    tiff_memmove_u8(buf2 + 4, buf2, N);
+    memmove(buf3 + 4, buf3, N);
+    if (memcmp(buf2 + 4, buf3 + 4, N) != 0)
+        return 1;
+
+    memcpy(buf2, buf1, N + 32);
+    memcpy(buf3, buf1, N + 32);
+
+    /* dest > src overlap */
+    tiff_memmove_u8(buf2, buf2 + 4, N);
+    memmove(buf3, buf3 + 4, N);
+    if (memcmp(buf2, buf3, N) != 0)
+        return 1;
+
+    free(buf1);
+    free(buf2);
+    free(buf3);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `tiff_memmove_u8` with NEON implementation
- use it when collapsing tiles and packing RGBA data
- add test verifying SIMD memmove behaviour

## Testing
- `pre-commit run --files libtiff/tiff_simd.h libtiff/tif_getimage.c libtiff/tif_lerc.c libtiff/tif_read.c tools/tiff2pdf.c test/CMakeLists.txt test/Makefile.am test/memmove_simd_test.c`
- `cmake --build build_dir -j$(nproc)`
- `ctest --test-dir build_dir -R memmove_simd_test --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684d4b7caac483219d47cb63ecde3106