### PR TITLE
Add __builtin_prefetch guard for NEON swab

### DIFF
--- a/libtiff/tif_swab.c
+++ b/libtiff/tif_swab.c
@@ -108,7 +108,9 @@ static void TIFFSwabArrayOfShortNeon(uint16_t *wp, tmsize_t n)
     size_t i = 0;
     for (; i + 8 <= (size_t)n; i += 8)
     {
-        TIFF_PREFETCH(wp + i + 32);
+#ifdef __GNUC__
+        __builtin_prefetch(wp + i + 32);
+#endif
         uint16x8_t v = vld1q_u16(wp + i);
         v = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(v)));
         vst1q_u16(wp + i, v);
@@ -171,7 +173,9 @@ static void TIFFSwabArrayOfLongNeon(uint32_t *lp, tmsize_t n)
     size_t i = 0;
     for (; i + 4 <= (size_t)n; i += 4)
     {
-        TIFF_PREFETCH(lp + i + 32);
+#ifdef __GNUC__
+        __builtin_prefetch(lp + i + 32);
+#endif
         uint32x4_t v = vld1q_u32(lp + i);
         uint8x16_t b = vreinterpretq_u8_u32(v);
         b = vrev32q_u8(b);
@@ -223,7 +227,9 @@ static void TIFFSwabArrayOfLong8Neon(uint64_t *lp, tmsize_t n)
     size_t i = 0;
     for (; i + 2 <= (size_t)n; i += 2)
     {
-        TIFF_PREFETCH(lp + i + 32);
+#ifdef __GNUC__
+        __builtin_prefetch(lp + i + 32);
+#endif
         uint64x2_t v = vld1q_u64(lp + i);
         uint8x16_t b = vreinterpretq_u8_u64(v);
         b = vrev64q_u8(b);


### PR DESCRIPTION
## Summary
- insert `__builtin_prefetch()` before NEON loads in swab helpers
- guard the new prefetch with `#ifdef __GNUC__`

## Testing
- `pre-commit run --files libtiff/tif_swab.c`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-lzw-single-strip, tiffcrop-extract-testfax4, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684e635e1f2883219801ff1bbec6014f