### PR TITLE
Improve PackBits NEON copy & add test

### DIFF
--- a/libtiff/tif_packbits.c
+++ b/libtiff/tif_packbits.c
@@ -140,8 +140,12 @@ static int PackBitsEncode(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s)
                 if (!TIFFFlushData1(tif))
                     return (0);
                 op = tif->tif_rawcp;
-                while (slop-- > 0)
-                    *op++ = *lastliteral++;
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+                memcpy_neon(op, lastliteral, (size_t)slop);
+#else
+                memcpy(op, lastliteral, (size_t)slop);
+#endif
+                op += slop;
                 lastliteral = tif->tif_rawcp;
             }
             else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -285,6 +285,12 @@ set_target_properties(pack_uring_benchmark PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(pack_uring_benchmark PRIVATE tiff tiff_port)
 list(APPEND simple_tests pack_uring_benchmark)
 
+add_executable(packbits_literal_run ../placeholder.h)
+target_sources(packbits_literal_run PRIVATE packbits_literal_run.c)
+set_target_properties(packbits_literal_run PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(packbits_literal_run PRIVATE tiff tiff_port)
+list(APPEND simple_tests packbits_literal_run)
+
 add_executable(threadpool_stress ../placeholder.h)
 target_sources(threadpool_stress PRIVATE threadpool_stress.c)
 set_target_properties(threadpool_stress PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -104,8 +104,8 @@ if TIFF_TESTS
 check_PROGRAMS = \
        ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
        defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
-       test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test memmove_simd_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS)
-       threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail
+       test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test memmove_simd_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS) \
+       packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail
 endif
 
 # Test scripts to execute
@@ -340,6 +340,8 @@ predictor_threadpool_benchmark_LDADD = $(LIBTIFF)
 
 pack_uring_benchmark_SOURCES = pack_uring_benchmark.c
 pack_uring_benchmark_LDADD = $(LIBTIFF)
+packbits_literal_run_SOURCES = packbits_literal_run.c
+packbits_literal_run_LDADD = $(LIBTIFF)
 threadpool_stress_SOURCES = threadpool_stress.c
 threadpool_stress_LDADD = $(LIBTIFF)
 uring_thread_stress_SOURCES = uring_thread_stress.c

--- a/test/packbits_literal_run.c
+++ b/test/packbits_literal_run.c
@@ -1,0 +1,65 @@
+#include "tiffio.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+    const char *filename = "packbits_literal_run.tif";
+    const uint32_t width = 20000;
+    const uint32_t height = 1;
+    uint8_t *buf = (uint8_t *)malloc(width * height);
+    if (!buf)
+        return 1;
+    for (uint32_t i = 0; i < width; i++)
+        buf[i] = (uint8_t)(i & 0xFF);
+
+    TIFF *tif = TIFFOpen(filename, "w");
+    if (!tif)
+    {
+        free(buf);
+        return 1;
+    }
+    TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+    TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+    TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+    TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 8);
+    TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_PACKBITS);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+    TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+    if (TIFFWriteScanline(tif, buf, 0, 0) < 0)
+    {
+        TIFFClose(tif);
+        free(buf);
+        return 1;
+    }
+    TIFFClose(tif);
+
+    tif = TIFFOpen(filename, "r");
+    if (!tif)
+    {
+        free(buf);
+        return 1;
+    }
+    uint8_t *read_buf = (uint8_t *)malloc(width);
+    if (!read_buf)
+    {
+        TIFFClose(tif);
+        free(buf);
+        return 1;
+    }
+    if (TIFFReadScanline(tif, read_buf, 0, 0) < 0)
+    {
+        TIFFClose(tif);
+        free(buf);
+        free(read_buf);
+        return 1;
+    }
+    TIFFClose(tif);
+
+    int ret = memcmp(buf, read_buf, width) != 0;
+    free(buf);
+    free(read_buf);
+    remove(filename);
+    return ret;
+}


### PR DESCRIPTION
## Summary
- optimize PackBits encoder by using `memcpy_neon` when NEON is available
- add `packbits_literal_run` test for large literal runs

## Testing
- `cmake --build . --target packbits_literal_run`
- `./test/packbits_literal_run` *(fails: TIFFClientOpenExt: Unknown mode flag 'w')*

------
https://chatgpt.com/codex/tasks/task_e_684e65e8f4308321a402115ee94944d9