### PR TITLE
Add prefetch hints before SIMD loads

### DIFF
--- a/libtiff/tif_bayer.c
+++ b/libtiff/tif_bayer.c
@@ -55,6 +55,7 @@ static void pack12_neon(const uint16_t *src, uint8_t *dst, size_t count,
     uint8x8_t mask4 = vdup_n_u8(0x0f);
     for (; i + 16 <= count; i += 16)
     {
+        __builtin_prefetch(src + i + 32);
         uint16x8x2_t v = vld2q_u16(src + i);
         uint16x8_t even = v.val[0];
         uint16x8_t odd = v.val[1];
@@ -95,6 +96,7 @@ static void unpack12_neon(const uint8_t *src, uint16_t *dst, size_t count,
     uint8x8_t mask4 = vdup_n_u8(0x0f);
     for (; i + 16 <= count; i += 16)
     {
+        __builtin_prefetch(src + 32);
         uint8x8x3_t v = vld3_u8(src);
         uint16x8_t out0, out1;
         if (!bigendian)

--- a/libtiff/tif_packbits.c
+++ b/libtiff/tif_packbits.c
@@ -44,6 +44,7 @@ static inline void memcpy_neon(uint8_t *dst, const uint8_t *src, size_t n)
     size_t i = 0;
     for (; i + 16 <= n; i += 16)
     {
+        __builtin_prefetch(src + i + 32);
         vst1q_u8(dst + i, vld1q_u8(src + i));
     }
     if (i < n)
@@ -56,6 +57,7 @@ static inline void memcpy_sse41(uint8_t *dst, const uint8_t *src, size_t n)
     size_t i = 0;
     for (; i + 16 <= n; i += 16)
     {
+        __builtin_prefetch(src + i + 32);
         __m128i v = _mm_loadu_si128((const __m128i *)(src + i));
         _mm_storeu_si128((__m128i *)(dst + i), v);
     }
@@ -374,7 +376,10 @@ static int PackBitsDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             {
                 size_t i = 0;
                 for (; i + 16 <= (size_t)n; i += 16)
+                {
+                    __builtin_prefetch((const uint8_t *)bp + i + 32);
                     vst1q_u8(op + i, vld1q_u8((const uint8_t *)bp + i));
+                }
                 if (i < (size_t)n)
                     memcpy(op + i, (const uint8_t *)bp + i, (size_t)n - i);
             }
@@ -388,6 +393,7 @@ static int PackBitsDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
                 size_t i = 0;
                 for (; i + 16 <= (size_t)n; i += 16)
                 {
+                    __builtin_prefetch((const uint8_t *)bp + i + 32);
                     __m128i v = _mm_loadu_si128(
                         (const __m128i *)((const uint8_t *)bp + i));
                     _mm_storeu_si128((__m128i *)(op + i), v);

--- a/libtiff/tif_predict.c
+++ b/libtiff/tif_predict.c
@@ -86,6 +86,10 @@ static void interleave4_avx2(uint8_t *dst, const uint8_t *src, tmsize_t wc,
     tmsize_t i = 0;
     for (; i + 31 < wc; i += 32)
     {
+        __builtin_prefetch(src + i + 32 + order[0] * wc);
+        __builtin_prefetch(src + i + 32 + order[1] * wc);
+        __builtin_prefetch(src + i + 32 + order[2] * wc);
+        __builtin_prefetch(src + i + 32 + order[3] * wc);
         __m256i v0 =
             _mm256_loadu_si256((const __m256i *)(src + i + order[0] * wc));
         __m256i v1 =
@@ -138,6 +142,10 @@ static void interleave4_neon(uint8_t *dst, const uint8_t *src, tmsize_t wc,
     tmsize_t i = 0;
     for (; i + 16 <= wc; i += 16)
     {
+        __builtin_prefetch(src + i + 32 + order[0] * wc);
+        __builtin_prefetch(src + i + 32 + order[1] * wc);
+        __builtin_prefetch(src + i + 32 + order[2] * wc);
+        __builtin_prefetch(src + i + 32 + order[3] * wc);
         uint8x16_t v0 = vld1q_u8(src + i + order[0] * wc);
         uint8x16_t v1 = vld1q_u8(src + i + order[1] * wc);
         uint8x16_t v2 = vld1q_u8(src + i + order[2] * wc);

--- a/libtiff/tif_swab.c
+++ b/libtiff/tif_swab.c
@@ -290,6 +290,7 @@ static void TIFFSwabArrayOfFloatNeon(float *fp, tmsize_t n)
     size_t i = 0;
     for (; i + 4 <= (size_t)n; i += 4)
     {
+        __builtin_prefetch(fp + i + 32);
         uint32x4_t v = vld1q_u32((const uint32_t *)(fp + i));
         uint8x16_t b = vreinterpretq_u8_u32(v);
         b = vrev32q_u8(b);
@@ -362,6 +363,7 @@ static void TIFFSwabArrayOfDoubleNeon(double *dp, tmsize_t n)
     size_t i = 0;
     for (; i + 2 <= (size_t)n; i += 2)
     {
+        __builtin_prefetch(dp + i + 32);
         uint64x2_t v = vld1q_u64((const uint64_t *)(dp + i));
         uint8x16_t b = vreinterpretq_u8_u64(v);
         b = vrev64q_u8(b);


### PR DESCRIPTION
## Summary
- add `__builtin_prefetch` before NEON and SSE loads in tif_packbits.c
- prefetch source data in tif_bayer.c NEON loops
- prefetch buffers in predictor interleave helpers
- add prefetch to floating point swab routines

## Testing
- `cmake ..` *(fails: could not find CharLS)*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684e692378908321b16ffc6031955e86