### PR TITLE
Add fallback NEON detection

### DIFF
--- a/libtiff/tiff_simd.c
+++ b/libtiff/tiff_simd.c
@@ -1,7 +1,19 @@
 #include "tiff_simd.h"
 #include <string.h>
+/*
+ * Runtime SIMD feature detection helpers.  When compiled on Linux the code
+ * attempts to use getauxval(AT_HWCAP) first.  If that function is not
+ * available, PR_GET_AUXV or the contents of /proc/cpuinfo are consulted.
+ */
 #if defined(__linux__)
+#if defined(__has_include)
+#if __has_include(<sys/auxv.h>)
 #include <sys/auxv.h>
+#define TIFF_HAVE_GETAUXVAL 1
+#endif
+#endif
+#include <stdio.h>
+#include <sys/prctl.h>
 #endif
 #if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) ||             \
     defined(_M_IX86)
@@ -88,19 +100,75 @@ static tiff_v16u8 sub_u8_sse41(tiff_v16u8 a, tiff_v16u8 b)
 }
 #endif
 
+/*
+ * detect_neon() checks for NEON availability at runtime on Linux.
+ * 1. If getauxval() is present, AT_HWCAP is inspected for NEON bits.
+ * 2. If getauxval() is unavailable, PR_GET_AUXV is tried.
+ * 3. As a last resort /proc/cpuinfo is scanned for "neon" or "asimd".
+ */
 static int detect_neon(void)
 {
 #if defined(HAVE_NEON) && defined(__linux__)
+    unsigned long hwcap = 0;
+#ifdef TIFF_HAVE_GETAUXVAL
 #ifdef __aarch64__
 #ifdef HWCAP_ASIMD
-    return (getauxval(AT_HWCAP) & HWCAP_ASIMD) != 0;
+    hwcap = getauxval(AT_HWCAP);
+    if (hwcap & HWCAP_ASIMD)
+        return 1;
 #endif
 #elif defined(__arm__)
 #ifdef HWCAP_NEON
-    return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0;
+    hwcap = getauxval(AT_HWCAP);
+    if (hwcap & HWCAP_NEON)
+        return 1;
 #endif
 #endif
+#endif /* TIFF_HAVE_GETAUXVAL */
+#ifdef PR_GET_AUXV
+    if (hwcap == 0)
+    {
+        unsigned long auxv[32];
+        long r = prctl(PR_GET_AUXV, auxv, sizeof(auxv), 0, 0);
+        if (r >= 0)
+        {
+            for (size_t i = 0; i + 1 < sizeof(auxv) / sizeof(auxv[0]); i += 2)
+            {
+                if (auxv[i] == AT_HWCAP)
+                {
+                    hwcap = auxv[i + 1];
+                    break;
+                }
+            }
+        }
+    }
+#endif /* PR_GET_AUXV */
+    if (hwcap == 0)
+    {
+        FILE *f = fopen("/proc/cpuinfo", "r");
+        if (f)
+        {
+            char line[256];
+            while (fgets(line, sizeof(line), f))
+            {
+                if (strstr(line, "neon") || strstr(line, "asimd"))
+                {
+                    fclose(f);
+                    return 1;
+                }
+            }
+            fclose(f);
+        }
+    }
+#ifdef HWCAP_ASIMD
+    if (hwcap & HWCAP_ASIMD)
+        return 1;
 #endif
+#ifdef HWCAP_NEON
+    if (hwcap & HWCAP_NEON)
+        return 1;
+#endif
+#endif /* HAVE_NEON && __linux__ */
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- detect NEON through `/proc/cpuinfo` or `prctl` when `getauxval` is missing
- comment the runtime SIMD detection strategy

## Testing
- `pre-commit run --files libtiff/tiff_simd.c`
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: tiffcrop-extract... and more)*

------
https://chatgpt.com/codex/tasks/task_e_684e79fa9cd083219fba5e231641b156