### PR TITLE
Enhance NEON horizontal differencing

### DIFF
--- a/libtiff/tif_predict.c
+++ b/libtiff/tif_predict.c
@@ -1182,13 +1182,24 @@ static int horDiff16(TIFF *tif, uint8_t *cp0, tmsize_t cc)
         {
             uint16_t *p = wp + 1;
             tmsize_t remaining = wc - 1;
-            while (remaining >= 8)
+            while (remaining >= 16)
+            {
+                uint16x8_t cur0 = vld1q_u16(p);
+                uint16x8_t cur1 = vld1q_u16(p + 8);
+                __builtin_prefetch(p + 32);
+                uint16x8_t prev0 = vld1q_u16(p - 1);
+                uint16x8_t prev1 = vld1q_u16(p + 7);
+                vst1q_u16(p, vsubq_u16(cur0, prev0));
+                vst1q_u16(p + 8, vsubq_u16(cur1, prev1));
+                p += 16;
+                remaining -= 16;
+            }
+            if (remaining >= 8)
             {
                 uint16x8_t cur = vld1q_u16(p);
                 __builtin_prefetch(p + 16);
                 uint16x8_t prev = vld1q_u16(p - 1);
-                uint16x8_t diff = vsubq_u16(cur, prev);
-                vst1q_u16(p, diff);
+                vst1q_u16(p, vsubq_u16(cur, prev));
                 p += 8;
                 remaining -= 8;
             }

--- a/libtiff/tif_strip_neon.c
+++ b/libtiff/tif_strip_neon.c
@@ -12,12 +12,22 @@ static void horiz_diff16_neon(uint16_t *row, uint32_t width)
         return;
     uint16_t *p = row + 1;
     uint32_t remaining = width - 1;
-    while (remaining >= 8)
+    while (remaining >= 16)
+    {
+        uint16x8_t cur0 = vld1q_u16(p);
+        uint16x8_t cur1 = vld1q_u16(p + 8);
+        uint16x8_t prev0 = vld1q_u16(p - 1);
+        uint16x8_t prev1 = vld1q_u16(p + 7);
+        vst1q_u16(p, vsubq_u16(cur0, prev0));
+        vst1q_u16(p + 8, vsubq_u16(cur1, prev1));
+        p += 16;
+        remaining -= 16;
+    }
+    if (remaining >= 8)
     {
         uint16x8_t cur = vld1q_u16(p);
         uint16x8_t prev = vld1q_u16(p - 1);
-        uint16x8_t diff = vsubq_u16(cur, prev);
-        vst1q_u16(p, diff);
+        vst1q_u16(p, vsubq_u16(cur, prev));
         p += 8;
         remaining -= 8;
     }


### PR DESCRIPTION
## Summary
- process 16 uint16 samples per iteration in `horDiff16`
- process 16 uint16 samples per iteration in `horiz_diff16_neon`

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Release -DHAVE_SSE41=0 ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-lzw-single-strip, tiffcrop-extract-testfax4, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684e7b749d6c83219a36dce04d5b2063