### PR TITLE
Add prefetch before NEON loads

### DIFF
--- a/libtiff/tif_getimage.c
+++ b/libtiff/tif_getimage.c
@@ -1596,6 +1596,7 @@ static void putgreytile_neon(TIFFRGBAImage *img, uint32_t *cp, uint32_t x,
         uint32_t ww = w;
         while (ww >= 16)
         {
+            __builtin_prefetch(pp + 64);
             uint8x16_t g = vld1q_u8(pp);
             if (invert)
                 g = vsubq_u8(maxv, g);

--- a/libtiff/tif_packbits.c
+++ b/libtiff/tif_packbits.c
@@ -44,7 +44,7 @@ static inline void memcpy_neon(uint8_t *dst, const uint8_t *src, size_t n)
     size_t i = 0;
     for (; i + 16 <= n; i += 16)
     {
-        __builtin_prefetch(src + i + 32);
+        __builtin_prefetch(src + i + 64);
         vst1q_u8(dst + i, vld1q_u8(src + i));
     }
     if (i < n)
@@ -377,7 +377,7 @@ static int PackBitsDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
                 size_t i = 0;
                 for (; i + 16 <= (size_t)n; i += 16)
                 {
-                    __builtin_prefetch((const uint8_t *)bp + i + 32);
+                    __builtin_prefetch((const uint8_t *)bp + i + 64);
                     vst1q_u8(op + i, vld1q_u8((const uint8_t *)bp + i));
                 }
                 if (i < (size_t)n)

--- a/libtiff/tif_predict.c
+++ b/libtiff/tif_predict.c
@@ -142,10 +142,10 @@ static void interleave4_neon(uint8_t *dst, const uint8_t *src, tmsize_t wc,
     tmsize_t i = 0;
     for (; i + 16 <= wc; i += 16)
     {
-        __builtin_prefetch(src + i + 32 + order[0] * wc);
-        __builtin_prefetch(src + i + 32 + order[1] * wc);
-        __builtin_prefetch(src + i + 32 + order[2] * wc);
-        __builtin_prefetch(src + i + 32 + order[3] * wc);
+        __builtin_prefetch(src + i + 64 + order[0] * wc);
+        __builtin_prefetch(src + i + 64 + order[1] * wc);
+        __builtin_prefetch(src + i + 64 + order[2] * wc);
+        __builtin_prefetch(src + i + 64 + order[3] * wc);
         uint8x16_t v0 = vld1q_u8(src + i + order[0] * wc);
         uint8x16_t v1 = vld1q_u8(src + i + order[1] * wc);
         uint8x16_t v2 = vld1q_u8(src + i + order[2] * wc);
@@ -501,8 +501,8 @@ static int horAcc8(TIFF *tif, uint8_t *cp0, tmsize_t cc)
                 while (remaining >= 16)
                 {
                     __builtin_prefetch(p + 16);
-                    uint8x16_t v = vld1q_u8(p);
                     __builtin_prefetch(p + 64);
+                    uint8x16_t v = vld1q_u8(p);
                     v = vaddq_u8(v, vextq_u8(vdupq_n_u8(0), v, 15));
                     v = vaddq_u8(v, vextq_u8(vdupq_n_u8(0), v, 14));
                     v = vaddq_u8(v, vextq_u8(vdupq_n_u8(0), v, 12));
@@ -1078,6 +1078,7 @@ static int horDiff8(TIFF *tif, uint8_t *cp0, tmsize_t cc)
                 while (remaining >= 32)
                 {
                     __builtin_prefetch(p + 16);
+                    __builtin_prefetch(p + 64);
                     uint8x16_t cur1 = vld1q_u8(p);
                     uint8x16_t cur2 = vld1q_u8(p + 16);
                     __builtin_prefetch(p + 128);
@@ -1091,8 +1092,8 @@ static int horDiff8(TIFF *tif, uint8_t *cp0, tmsize_t cc)
                 while (remaining >= 16)
                 {
                     __builtin_prefetch(p + 16);
-                    uint8x16_t cur = vld1q_u8(p);
                     __builtin_prefetch(p + 64);
+                    uint8x16_t cur = vld1q_u8(p);
                     uint8x16_t prev = vld1q_u8(p - 1);
                     vst1q_u8(p, vsubq_u8(cur, prev));
                     p += 16;
@@ -1488,8 +1489,8 @@ static int fpDiff(TIFF *tif, uint8_t *cp0, tmsize_t cc)
         while (remaining >= 16)
         {
             __builtin_prefetch(p + 16);
-            uint8x16_t cur = vld1q_u8(p);
             __builtin_prefetch(p + 64);
+            uint8x16_t cur = vld1q_u8(p);
             uint8x16_t prev = vld1q_u8(p - 1);
             uint8x16_t diff = vsubq_u8(cur, prev);
             vst1q_u8(p, diff);

--- a/libtiff/tif_swab.c
+++ b/libtiff/tif_swab.c
@@ -506,11 +506,13 @@ static void TIFFReverseBitsNeonImpl(uint8_t *cp, tmsize_t n)
     static const uint8_t nibble_reverse[16] = {0x0, 0x8, 0x4, 0xc, 0x2, 0xa,
                                                0x6, 0xe, 0x1, 0x9, 0x5, 0xd,
                                                0x3, 0xb, 0x7, 0xf};
+    __builtin_prefetch(nibble_reverse + 64);
     uint8x16_t table = vld1q_u8(nibble_reverse);
     uint8x16_t mask = vdupq_n_u8(0x0f);
     size_t i = 0;
     for (; i + 16 <= (size_t)n; i += 16)
     {
+        __builtin_prefetch(cp + i + 64);
         uint8x16_t v = vld1q_u8(cp + i);
         uint8x16_t lo = vandq_u8(v, mask);
         uint8x16_t hi = vshrq_n_u8(v, 4);

--- a/libtiff/tiff_simd.c
+++ b/libtiff/tiff_simd.c
@@ -56,6 +56,7 @@ static tiff_v16u8 sub_u8_scalar(tiff_v16u8 a, tiff_v16u8 b)
 static tiff_v16u8 loadu_u8_neon(const uint8_t *ptr)
 {
     tiff_v16u8 r;
+    __builtin_prefetch(ptr + 64);
     r.n = vld1q_u8(ptr);
     return r;
 }

--- a/libtiff/tiff_simd.h
+++ b/libtiff/tiff_simd.h
@@ -84,7 +84,10 @@ extern "C"
                 n--;
             }
             for (; n >= 16; n -= 16, dst += 16, src += 16)
+            {
+                __builtin_prefetch(src + 64);
                 vst1q_u8(dst, vld1q_u8(src));
+            }
             while (n--)
                 *dst++ = *src++;
         }
@@ -103,6 +106,7 @@ extern "C"
             {
                 dst -= 16;
                 src -= 16;
+                __builtin_prefetch(src - 64);
                 vst1q_u8(dst, vld1q_u8(src));
             }
             while (n--)


### PR DESCRIPTION
## Summary
- prefetch ahead of NEON `vld1q_u8` loads
- update NEON copy helpers with extra prefetch

## Testing
- `cmake -DBUILD_TESTING=ON ..`
- `make -j$(nproc)`
- `ctest` *(fails: tiffcrop tests report missing mode flag)*

------
https://chatgpt.com/codex/tasks/task_e_684e808ca3f883219f4f88f82ba7a33b