### PR TITLE
Initialize thread pool using cpu count

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ The io_uring backend uses a queue depth of 8 by default.  Set the
 `TIFF_URING_DEPTH` environment variable or call
 `TIFFOpenOptionsSetURingQueueDepth()` to override it.
 
+The thread pool is initialized with the number of online processors by
+default. Set the `TIFF_THREAD_COUNT` environment variable or call
+`TIFFSetThreadCount()` to override this value.
+
 ## Testing and Validation
 Configure with testing enabled and run the full suite:
 ```bash


### PR DESCRIPTION
## Summary
- default thread pool size uses the number of online CPUs
- allow `TIFF_THREAD_COUNT` to override the default
- document thread pool default in README

## Testing
- `pre-commit run --files libtiff/tiff_threadpool.c README.md`
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest` *(fails: tiffcrop-extractz14-32bpp-None and others)*

------
https://chatgpt.com/codex/tasks/task_e_684e87230d188321be63de24d59bee51