### PR TITLE
Add configurable thread pool queue limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ The io_uring backend uses a queue depth of 8 by default.  Set the
 
 The thread pool is initialized with the number of online processors by
 default. Set the `TIFF_THREAD_COUNT` environment variable or call
-`TIFFSetThreadCount()` to override this value.
+`TIFFSetThreadCount()` to override this value. Use
+`TIFFSetThreadPoolSize()` to additionally control the task queue limit.
 
 ## Testing and Validation
 Configure with testing enabled and run the full suite:

--- a/libtiff/libtiff.map
+++ b/libtiff/libtiff.map
@@ -231,5 +231,6 @@ LIBTIFF_4.7.1 {
     _TIFFThreadPoolSubmit;
     _TIFFThreadPoolWait;
     TIFFSetThreadCount;
+    TIFFSetThreadPoolSize;
     TIFFGetThreadCount;
 } LIBTIFF_4.6.1;

--- a/libtiff/tiffio.h
+++ b/libtiff/tiffio.h
@@ -573,6 +573,7 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
 
     /* Thread pool management */
     extern void TIFFSetThreadCount(TIFF *, int);
+    extern void TIFFSetThreadPoolSize(TIFF *, int, int);
     extern int TIFFGetThreadCount(TIFF *);
     extern void TIFFInitSIMD(void);
     extern tmsize_t TIFFReadEncodedStrip(TIFF *tif, uint32_t strip, void *buf,


### PR DESCRIPTION
## Summary
- expand `TIFFThreadPool` with a `max_queue` field
- create `_TIFFThreadPoolInitWithSize` helper and public `TIFFSetThreadPoolSize`
- default queue limit to 256 for backward compatibility
- document new API in README

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-lzw-single-strip, tiffcrop-extract-testfax4, tiffcrop-extract-testfax3_bug_513, tiffcrop-extract-32bpp-None, tiffcrop-extractz14-custom_dir_EXIF_GPS, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684e891838c8832191263e88a5bbfb11