### PR TITLE
Add auto scaling to thread pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,10 @@ around 3× faster than the scalar implementation on the same device.
 Build with `-Dthreadpool=ON` (CMake) or `--enable-multithreading` (Autotools)
 to enable the internal worker pool. By default the number of threads matches
 the available processors. Override this with the `TIFF_THREAD_COUNT`
-environment variable or by calling `TIFFSetThreadCount()`. The task queue
-limit may be changed via `TIFFSetThreadPoolSize()`.
+environment variable (set to an integer or `auto`) or by calling
+`TIFFSetThreadCount()`. The task queue limit may be changed via
+`TIFFSetThreadPoolSize()`. Passing `0` to `TIFFSetThreadPoolSize()` sizes the
+pool automatically based on the queued tasks.
 
 ## io_uring Configuration
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -290,6 +290,12 @@ set_target_properties(predictor_threadpool_benchmark PROPERTIES LINKER_LANGUAGE 
 target_link_libraries(predictor_threadpool_benchmark PRIVATE tiff tiff_port)
 list(APPEND simple_tests predictor_threadpool_benchmark)
 
+add_executable(predictor_threadpool_resize ../placeholder.h)
+target_sources(predictor_threadpool_resize PRIVATE predictor_threadpool_resize.c)
+set_target_properties(predictor_threadpool_resize PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(predictor_threadpool_resize PRIVATE tiff tiff_port)
+list(APPEND simple_tests predictor_threadpool_resize)
+
 add_executable(pack_uring_benchmark ../placeholder.h)
 target_sources(pack_uring_benchmark PRIVATE pack_uring_benchmark.c)
 set_target_properties(pack_uring_benchmark PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -105,7 +105,7 @@ check_PROGRAMS = \
        ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
        defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
        test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test memmove_simd_test reverse_bits_neon_test bayer_pack_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS) \
-       packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail
+       packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize
 endif
 
 # Test scripts to execute
@@ -343,6 +343,9 @@ bayer_pack_test_LDADD = $(LIBTIFF)
 
 predictor_threadpool_benchmark_SOURCES = predictor_threadpool_benchmark.c
 predictor_threadpool_benchmark_LDADD = $(LIBTIFF)
+
+predictor_threadpool_resize_SOURCES = predictor_threadpool_resize.c
+predictor_threadpool_resize_LDADD = $(LIBTIFF)
 
 pack_uring_benchmark_SOURCES = pack_uring_benchmark.c
 pack_uring_benchmark_LDADD = $(LIBTIFF)

--- a/test/predictor_threadpool_resize.c
+++ b/test/predictor_threadpool_resize.c
@@ -1,0 +1,71 @@
+#include "strip_neon.h"
+#include "tiff_threadpool.h"
+#include "tiffiop.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+typedef struct
+{
+    const uint16_t *src;
+    uint32_t width;
+    uint32_t height;
+    size_t loops;
+    TIFF *tif;
+} Task;
+
+static void bench_task(void *arg)
+{
+    Task *t = (Task *)arg;
+    for (size_t i = 0; i < t->loops; i++)
+    {
+        size_t out_size = 0;
+        uint8_t *dst = TIFFAssembleStripNEON(NULL, t->src, t->width, t->height,
+                                             1, 0, &out_size);
+        free(dst);
+    }
+}
+
+int main(void)
+{
+    TIFF *tif = TIFFOpen("resize.tmp", "w+");
+    if (!tif)
+        return 1;
+    TIFFSetThreadPoolSize(tif, 1, 256);
+
+    const int tasks = 8;
+    const uint32_t width = 256, height = 256;
+    size_t count = (size_t)width * height;
+    uint16_t *buf = (uint16_t *)malloc(count * sizeof(uint16_t));
+    if (!buf)
+        return 1;
+    for (size_t i = 0; i < count; i++)
+        buf[i] = (uint16_t)(i & 0x0FFF);
+
+    Task *tarray = (Task *)calloc(tasks, sizeof(Task));
+    if (!tarray)
+        return 1;
+    for (int t = 0; t < tasks; t++)
+    {
+        tarray[t].src = buf;
+        tarray[t].width = width;
+        tarray[t].height = height;
+        tarray[t].loops = 20;
+        tarray[t].tif = tif;
+        _TIFFThreadPoolSubmit(tif->tif_threadpool, bench_task, &tarray[t]);
+    }
+
+    TIFFSetThreadPoolSize(tif, 0, 256);
+    int new_workers = TIFFGetThreadCount(tif);
+
+    for (int t = 0; t < tasks; t++)
+        _TIFFThreadPoolSubmit(tif->tif_threadpool, bench_task, &tarray[t]);
+
+    _TIFFThreadPoolWait(tif->tif_threadpool);
+    int ret = (new_workers <= 1);
+    free(tarray);
+    free(buf);
+    TIFFClose(tif);
+    unlink("resize.tmp");
+    return ret;
+}


### PR DESCRIPTION
## Summary
- allow `TIFF_THREAD_COUNT=auto`
- resize threadpool based on queued tasks when `TIFFSetThreadPoolSize()` is passed 0
- document auto sizing
- add predictor threadpool resize test

## Testing
- `pre-commit run --files libtiff/tiff_threadpool.c README.md test/CMakeLists.txt test/Makefile.am test/predictor_threadpool_resize.c`
- `ctest --output-on-failure` *(fails: tiffcrop-R90-rgb-3c-16b, tiffcrop-R90-rgb-3c-8b, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684e94c57a4c8321b7b2682722851d65