### PR TITLE
Add persistent predictor work buffer

### DIFF
--- a/libtiff/tif_predict.h
+++ b/libtiff/tif_predict.h
@@ -45,6 +45,10 @@ typedef struct
     tmsize_t stride;  /* sample stride over data */
     tmsize_t rowsize; /* tile/strip row size */
 
+    /* Temporary buffer used by PredictorEncodeRow/Tile */
+    uint8_t *work_buffer;
+    tmsize_t work_buffer_size;
+
     TIFFCodeMethod encoderow;           /* parent codec encode/decode row */
     TIFFCodeMethod encodestrip;         /* parent codec encode/decode strip */
     TIFFCodeMethod encodetile;          /* parent codec encode/decode tile */


### PR DESCRIPTION
## Summary
- add work_buffer to `TIFFPredictorState`
- allocate/reuse buffer during setup and encoding
- free buffer in predictor cleanup

## Testing
- `pre-commit run --files libtiff/tif_predict.c libtiff/tif_predict.h`
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build .`
- `ctest` *(fails: Returned failed status 253)*

------
https://chatgpt.com/codex/tasks/task_e_684e9b3370c48321bfa05778260e0511