### PR TITLE
Add NEON prefetch hints

### DIFF
--- a/libtiff/tif_bayer.c
+++ b/libtiff/tif_bayer.c
@@ -350,6 +350,7 @@ static void pack16_neon(const uint16_t *src, uint8_t *dst, size_t count,
     size_t i = 0;
     for (; i + 8 <= count; i += 8)
     {
+        __builtin_prefetch(src + i + 16);
         uint16x8_t v = vld1q_u16(src + i);
         uint8x8_t lo = vmovn_u16(v);
         uint8x8_t hi = vshrn_n_u16(v, 8);
@@ -377,6 +378,7 @@ static void unpack16_neon(const uint8_t *src, uint16_t *dst, size_t count,
     size_t i = 0;
     for (; i + 8 <= count; i += 8)
     {
+        __builtin_prefetch(src + 16);
         uint8x8x2_t v = vld2_u8(src);
         uint16x8_t out;
         if (!bigendian)

--- a/libtiff/tif_predict.c
+++ b/libtiff/tif_predict.c
@@ -1302,6 +1302,7 @@ static int horDiff32(TIFF *tif, uint8_t *cp0, tmsize_t cc)
             tmsize_t remaining = wc - 1;
             while (remaining >= 4)
             {
+                __builtin_prefetch(p + 8);
                 uint32x4_t cur = vld1q_u32(p);
                 uint32x4_t prev = vld1q_u32(p - 1);
                 uint32x4_t diff = vsubq_u32(cur, prev);
@@ -1364,6 +1365,7 @@ static int horDiff64(TIFF *tif, uint8_t *cp0, tmsize_t cc)
 #ifdef __aarch64__
             while (remaining >= 4)
             {
+                __builtin_prefetch(p + 8);
                 uint64x2x2_t cur = vld1q_u64_x2(p);
                 uint64x2x2_t prev = vld1q_u64_x2(p - 1);
                 cur.val[0] = vsubq_u64(cur.val[0], prev.val[0]);
@@ -1375,6 +1377,7 @@ static int horDiff64(TIFF *tif, uint8_t *cp0, tmsize_t cc)
 #endif
             while (remaining >= 2)
             {
+                __builtin_prefetch(p + 4);
                 uint64x2_t cur = vld1q_u64(p);
                 uint64x2_t prev = vld1q_u64(p - 1);
                 uint64x2_t diff = vsubq_u64(cur, prev);


### PR DESCRIPTION
## Summary
- add prefetch calls in NEON pack16/unpack16 routines
- prefetch upcoming data when computing 32/64-bit horizontal diffs

## Testing
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest` *(fails: tiffcrop tests report 'Unknown mode flag')*

------
https://chatgpt.com/codex/tasks/task_e_684e9dc6ee1083219df18a30822f6ff3