### PR TITLE
Handle potential overlap in WebP decode

### DIFF
--- a/libtiff/tif_webp.c
+++ b/libtiff/tif_webp.c
@@ -345,7 +345,8 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             }
             else
             {
-                memcpy(op, buf + (sp->last_y * stride), occ);
+                /* Use SIMD-accelerated helper in case of overlapping buffers */
+                tiff_memmove_u8(op, buf + (sp->last_y * stride), occ);
             }
 
             tif->tif_rawcp += tif->tif_rawcc;


### PR DESCRIPTION
## Summary
- use `tiff_memmove_u8` when copying WebP decode output
- document the SIMD helper usage

## Testing
- `cmake ..`
- `cmake --build . -j`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-lzw-single-strip, tiffcrop-extract-testfax4, tiffcrop-extract-testfax3_bug_513, tiffcrop-extract-32bpp-None, tiffcrop-extractz14-custom_dir_EXIF_GPS, tiffcrop-extractz14-logluv-3c-16b, tiffcrop-extractz14-minisblack-1c-16b, tiffcrop-extractz14-minisblack-1c-8b, tiffcrop-extractz14-minisblack-2c-8b-alpha, tiffcrop-extractz14-miniswhite-1c-1b, tiffcrop-extractz14-palette-1c-1b, tiffcrop-extractz14-palette-1c-4b, tiffcrop-extractz14-palette-1c-8b, tiffcrop-extractz14-rgb-3c-16b, tiffcrop-extractz14-rgb-3c-8b, tiffcrop-extractz14-quad-lzw-compat, tiffcrop-extractz14-lzw-single-strip, tiffcrop-extractz14-testfax4, tiffcrop-extractz14-testfax3_bug_513, tiffcrop-extractz14-32bpp-None)*

------
https://chatgpt.com/codex/tasks/task_e_684eafb3eb488321b1bd25af13c376de