### PR TITLE
Fix mode string handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ test/o-*
 .vs
 cmake-build*
 build*
+Testing/

--- a/libtiff/tif_open.c
+++ b/libtiff/tif_open.c
@@ -501,7 +501,11 @@ TIFF *TIFFClientOpenExt(const char *name, const char *mode,
      * option permits applications that only want to look at the tags,
      * for example, to get the unadulterated TIFF tag information.
      */
-    for (cp = mode; *cp; cp++)
+    /* Skip the initial access mode character and optional '+' */
+    cp = mode + 1;
+    if ((mode[0] == 'r' || mode[0] == 'w' || mode[0] == 'a') && mode[1] == '+')
+        cp++;
+    for (; *cp; cp++)
         switch (*cp)
         {
             case 'b':
@@ -550,6 +554,9 @@ TIFF *TIFFClientOpenExt(const char *name, const char *mode,
                 break;
             case 'h':
                 tif->tif_flags |= TIFF_HEADERONLY;
+                break;
+            case '4':
+                /* ClassicTIFF is the default, so just ignore */
                 break;
             case '8':
                 if (m & O_CREAT)


### PR DESCRIPTION
## Summary
- ignore the first mode character and optional `+` in `TIFFClientOpenExt`
- accept `4` as a valid mode flag for ClassicTIFF
- ignore local CTest output directory

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)`
- `ctest -j$(nproc) --output-on-failure` *(fails: 5 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684eba11230c8321a7fb08da6909c604