### PR TITLE
Add runtime io_uring queue depth tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,10 @@ pool automatically based on the queued tasks.
 
 io_uring support requires Linux 5.1 and liburing. Enable it with
 `-Dio-uring=ON` (CMake) or `--enable-io-uring` (Autotools). The queue depth
-defaults to 8 but can be modified through the `TIFF_URING_DEPTH`
-environment variable or by calling
-`TIFFOpenOptionsSetURingQueueDepth()`.
+defaults to 8 but may be tuned through the `TIFF_URING_DEPTH` environment
+variable, via `TIFFOpenOptionsSetURingQueueDepth()` before opening a file, or at
+runtime with `TIFFSetURingQueueDepth()`. Any positive value accepted by the
+kernel is allowed.
 
 ## Memory Mapping Tuning
 

--- a/libtiff/libtiff.def
+++ b/libtiff/libtiff.def
@@ -213,3 +213,5 @@ EXPORTS	TIFFAccessTagMethods
         TIFFSetUseSSE41
         TIFFSetMapSize
         TIFFSetMapAdvice
+        TIFFSetURingQueueDepth
+        TIFFGetURingQueueDepth

--- a/libtiff/libtiff.map
+++ b/libtiff/libtiff.map
@@ -246,4 +246,6 @@ LIBTIFF_4.7.1 {
     TIFFSetUseSSE41;
     TIFFSetMapSize;
     TIFFSetMapAdvice;
+    TIFFSetURingQueueDepth;
+    TIFFGetURingQueueDepth;
 } LIBTIFF_4.6.1;

--- a/libtiff/tiffio.h
+++ b/libtiff/tiffio.h
@@ -254,7 +254,7 @@ struct _TIFFRGBAImage
  * Macros for extracting components from the
  * packed ABGR form returned by TIFFReadRGBAImage.
  */
-#define TIFFGetR(abgr) ((abgr) & 0xff)
+#define TIFFGetR(abgr) ((abgr)&0xff)
 #define TIFFGetG(abgr) (((abgr) >> 8) & 0xff)
 #define TIFFGetB(abgr) (((abgr) >> 16) & 0xff)
 #define TIFFGetA(abgr) (((abgr) >> 24) & 0xff)
@@ -534,9 +534,8 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
                                          TIFFErrorHandlerExtR handler,
                                          void *warnhandler_user_data);
 #ifdef USE_IO_URING
-    extern void
-    TIFFOpenOptionsSetURingQueueDepth(TIFFOpenOptions *opts,
-                                      unsigned int depth);
+    extern void TIFFOpenOptionsSetURingQueueDepth(TIFFOpenOptions *opts,
+                                                  unsigned int depth);
 #endif
 
     extern TIFF *TIFFOpen(const char *, const char *);
@@ -582,6 +581,10 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
     extern void TIFFSetUseSSE41(int);
     extern void TIFFSetMapSize(tmsize_t size);
     extern void TIFFSetMapAdvice(int fadvise_flags, int madvise_flags);
+#ifdef USE_IO_URING
+    extern int TIFFSetURingQueueDepth(TIFF *tif, unsigned int depth);
+    extern unsigned int TIFFGetURingQueueDepth(TIFF *tif);
+#endif
     extern tmsize_t TIFFReadEncodedStrip(TIFF *tif, uint32_t strip, void *buf,
                                          tmsize_t size);
     extern tmsize_t TIFFReadRawStrip(TIFF *tif, uint32_t strip, void *buf,


### PR DESCRIPTION
## Summary
- allow queue depths above 1024 and let the kernel validate
- add TIFFSetURingQueueDepth/TIFFGetURingQueueDepth
- document io_uring advanced tuning

## Testing
- `pre-commit run --files README.md libtiff/libtiff.def libtiff/libtiff.map libtiff/tif_uring.c libtiff/tiffio.h`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec89b1af48321997639e995f1a2b3