### PR TITLE
Add SIMD memset helper

### DIFF
--- a/libtiff/tif_fax3.c
+++ b/libtiff/tif_fax3.c
@@ -447,7 +447,7 @@ static inline void fax_zero_neon(uint8_t **cpp, int32_t n)
             vst1q_u8(cp + i, v);
     }
     if (i < n)
-        memset(cp + i, 0, (size_t)(n - i));
+        tiff_memset_u8(cp + i, 0, (size_t)(n - i));
     *cpp = cp + n;
 }
 #define FILL(n, cp) fax_fill_neon(&(cp), (n))
@@ -678,8 +678,8 @@ static int Fax3SetupState(TIFF *tif)
         "for Group 3/4 run arrays");
     if (dsp->runs == NULL)
         return (0);
-    memset(dsp->runs, 0,
-           TIFFSafeMultiply(uint32_t, dsp->nruns, 2) * sizeof(uint32_t));
+    tiff_memset_u8(dsp->runs, 0,
+                   TIFFSafeMultiply(uint32_t, dsp->nruns, 2) * sizeof(uint32_t));
     dsp->curruns = dsp->runs;
     if (needsRefLine)
         dsp->refruns = dsp->runs + dsp->nruns;

--- a/libtiff/tif_jbig.c
+++ b/libtiff/tif_jbig.c
@@ -92,7 +92,7 @@ static int JBIGDecode(TIFF *tif, uint8_t *buffer, tmsize_t size, uint16_t s)
                       jbg_strerror(decodeStatus)
 #endif
         );
-        memset(buffer, 0, (size_t)size);
+        tiff_memset_u8(buffer, 0, (size_t)size);
         jbg_dec_free(&decoder);
         return 0;
     }
@@ -100,7 +100,7 @@ static int JBIGDecode(TIFF *tif, uint8_t *buffer, tmsize_t size, uint16_t s)
     decodedSize = jbg_dec_getsize(&decoder);
     if ((tmsize_t)decodedSize < size)
     {
-        memset(buffer + decodedSize, 0, (size_t)(size - decodedSize));
+        tiff_memset_u8(buffer + decodedSize, 0, (size_t)(size - decodedSize));
         TIFFWarningExtR(tif, "JBIG",
                         "Only decoded %lu bytes, whereas %" TIFF_SSIZE_FORMAT
                         " requested",

--- a/libtiff/tif_lerc.c
+++ b/libtiff/tif_lerc.c
@@ -755,7 +755,7 @@ static int LERCDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 
     if (sp->uncompressed_buffer == NULL)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module, "Uncompressed buffer not allocated");
         return 0;
     }
@@ -763,7 +763,7 @@ static int LERCDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
     if ((uint64_t)sp->uncompressed_offset + (uint64_t)occ >
         sp->uncompressed_size)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module, "Too many bytes read");
         return 0;
     }

--- a/libtiff/tif_lzma.c
+++ b/libtiff/tif_lzma.c
@@ -175,7 +175,7 @@ static int LZMADecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 
     if (sp->read_error)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module,
                       "LZMADecode: Scanline %" PRIu32 " cannot be read due to "
                       "previous error",
@@ -192,7 +192,7 @@ static int LZMADecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
     {
         // read_error not set here as this is a usage issue that can be
         // recovered in a following call.
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module,
                       "Liblzma cannot deal with buffers this size");
         return 0;
@@ -217,7 +217,7 @@ static int LZMADecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             if (r != LZMA_OK)
             {
                 sp->read_error = 1;
-                memset(op, 0, (size_t)occ);
+                tiff_memset_u8(op, 0, (size_t)occ);
                 TIFFErrorExtR(tif, module,
                               "Error initializing the stream decoder, %s",
                               LZMAStrerror(r));
@@ -238,7 +238,7 @@ static int LZMADecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
     if (sp->stream.avail_out != 0)
     {
         sp->read_error = 1;
-        memset(sp->stream.next_out, 0, sp->stream.avail_out);
+        tiff_memset_u8(sp->stream.next_out, 0, sp->stream.avail_out);
         TIFFErrorExtR(tif, module,
                       "Not enough data at scanline %" PRIu32
                       " (short %" TIFF_SIZE_FORMAT " bytes)",

--- a/libtiff/tif_lzw.c
+++ b/libtiff/tif_lzw.c
@@ -416,7 +416,7 @@ static int LZWDecode(TIFF *tif, uint8_t *op0, tmsize_t occ0, uint16_t s)
 
     if (sp->read_error)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module,
                       "LZWDecode: Scanline %" PRIu32 " cannot be read due to "
                       "previous error",
@@ -731,7 +731,7 @@ after_loop:
 
     if (occ > 0)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         sp->read_error = 1;
         TIFFErrorExtR(tif, module,
                       "Not enough data at scanline %" PRIu32 " (short %" PRIu64
@@ -742,14 +742,14 @@ after_loop:
     return (1);
 
 no_eoi:
-    memset(op, 0, (size_t)occ);
+    tiff_memset_u8(op, 0, (size_t)occ);
     sp->read_error = 1;
     TIFFErrorExtR(tif, module,
                   "LZWDecode: Strip %" PRIu32 " not terminated with EOI code",
                   tif->tif_curstrip);
     return 0;
 error_code:
-    memset(op, 0, (size_t)occ);
+    tiff_memset_u8(op, 0, (size_t)occ);
     sp->read_error = 1;
     TIFFErrorExtR(tif, tif->tif_name, "Using code not yet in table");
     return 0;

--- a/libtiff/tif_packbits.c
+++ b/libtiff/tif_packbits.c
@@ -416,7 +416,7 @@ static int PackBitsDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
     tif->tif_rawcc = cc;
     if (occ > 0)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module, "Not enough data for scanline %" PRIu32,
                       tif->tif_row);
         return (0);

--- a/libtiff/tif_pixarlog.c
+++ b/libtiff/tif_pixarlog.c
@@ -861,7 +861,7 @@ static int PixarLogDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             TIFFErrorExtR(tif, module,
                           "%" PRIu16 " bit input not supported in PixarLog",
                           td->td_bitspersample);
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             return 0;
     }
 
@@ -882,14 +882,14 @@ static int PixarLogDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
     if (sp->stream.avail_out != nsamples * sizeof(uint16_t))
     {
         TIFFErrorExtR(tif, module, "ZLib cannot deal with buffers this size");
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         return (0);
     }
     /* Check that we will not fill more than what was allocated */
     if ((tmsize_t)sp->stream.avail_out > sp->tbuf_size)
     {
         TIFFErrorExtR(tif, module, "sp->stream.avail_out > sp->tbuf_size");
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         return (0);
     }
     do
@@ -904,14 +904,14 @@ static int PixarLogDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             TIFFErrorExtR(
                 tif, module, "Decoding error at scanline %" PRIu32 ", %s",
                 tif->tif_row, sp->stream.msg ? sp->stream.msg : "(null)");
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             return (0);
         }
         if (state != Z_OK)
         {
             TIFFErrorExtR(tif, module, "ZLib error: %s",
                           sp->stream.msg ? sp->stream.msg : "(null)");
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             return (0);
         }
     } while (sp->stream.avail_out > 0);
@@ -923,7 +923,7 @@ static int PixarLogDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
                       "Not enough data at scanline %" PRIu32
                       " (short %u bytes)",
                       tif->tif_row, sp->stream.avail_out);
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         return (0);
     }
 
@@ -985,7 +985,7 @@ static int PixarLogDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             default:
                 TIFFErrorExtR(tif, module, "Unsupported bits/sample: %" PRIu16,
                               td->td_bitspersample);
-                memset(op, 0, (size_t)occ);
+                tiff_memset_u8(op, 0, (size_t)occ);
                 return (0);
         }
     }

--- a/libtiff/tif_read.c
+++ b/libtiff/tif_read.c
@@ -131,8 +131,8 @@ static int TIFFReadAndRealloc(TIFF *tif, tmsize_t size, tmsize_t rawdata_offset,
         already_read += bytes_read;
         if (bytes_read != to_read)
         {
-            memset(tif->tif_rawdata + rawdata_offset + already_read, 0,
-                   tif->tif_rawdatasize - rawdata_offset - already_read);
+            tiff_memset_u8(tif->tif_rawdata + rawdata_offset + already_read, 0,
+                           tif->tif_rawdatasize - rawdata_offset - already_read);
             if (is_strip)
             {
                 TIFFErrorExtR(tif, module,
@@ -476,7 +476,7 @@ int TIFFReadScanline(TIFF *tif, void *buf, uint32_t row, uint16_t sample)
     {
         /* See TIFFReadEncodedStrip comment regarding TIFFTAG_FAXFILLFUNC. */
         if (buf)
-            memset(buf, 0, (size_t)tif->tif_scanlinesize);
+            tiff_memset_u8(buf, 0, (size_t)tif->tif_scanlinesize);
     }
     return (e > 0 ? 1 : -1);
 }
@@ -567,7 +567,7 @@ tmsize_t TIFFReadEncodedStrip(TIFF *tif, uint32_t strip, void *buf,
         /* The output buf may be NULL, in particular if TIFFTAG_FAXFILLFUNC
            is being used. Thus, memset must be conditional on buf not NULL. */
         if (buf)
-            memset(buf, 0, (size_t)stripsize);
+            tiff_memset_u8(buf, 0, (size_t)stripsize);
         return ((tmsize_t)(-1));
     }
     if ((*tif->tif_decodestrip)(tif, buf, stripsize, plane) <= 0)
@@ -991,7 +991,7 @@ tmsize_t TIFFReadEncodedTile(TIFF *tif, uint32_t tile, void *buf, tmsize_t size)
     {
         /* See TIFFReadEncodedStrip comment regarding TIFFTAG_FAXFILLFUNC. */
         if (buf)
-            memset(buf, 0, (size_t)size);
+            tiff_memset_u8(buf, 0, (size_t)size);
         return ((tmsize_t)(-1));
     }
     else if ((*tif->tif_decodetile)(tif, (uint8_t *)buf, size,
@@ -1599,7 +1599,7 @@ int TIFFReadFromUserBuffer(TIFF *tif, uint32_t strile, void *inbuf,
             ret = 0;
             /* See related TIFFReadEncodedStrip comment. */
             if (outbuf)
-                memset(outbuf, 0, (size_t)outsize);
+                tiff_memset_u8(outbuf, 0, (size_t)outsize);
         }
         else if (!(*tif->tif_decodetile)(
                      tif, (uint8_t *)outbuf, outsize,
@@ -1628,7 +1628,7 @@ int TIFFReadFromUserBuffer(TIFF *tif, uint32_t strile, void *inbuf,
                 ret = 0;
                 /* See related TIFFReadEncodedStrip comment. */
                 if (outbuf)
-                    memset(outbuf, 0, (size_t)outsize);
+                    tiff_memset_u8(outbuf, 0, (size_t)outsize);
             }
             else if (!(*tif->tif_decodestrip)(
                          tif, (uint8_t *)outbuf, outsize,

--- a/libtiff/tif_thunder.c
+++ b/libtiff/tif_thunder.c
@@ -157,7 +157,7 @@ static int ThunderDecode(TIFF *tif, uint8_t *op0, tmsize_t maxpixels)
     if (npixels != maxpixels)
     {
         uint8_t *op_end = op0 + (maxpixels + 1) / 2;
-        memset(op, 0, (size_t)(op_end - op));
+        tiff_memset_u8(op, 0, (size_t)(op_end - op));
         TIFFErrorExtR(tif, module,
                       "%s data at scanline %lu (%" PRIu64 " != %" PRIu64 ")",
                       npixels < maxpixels ? "Not enough" : "Too much",

--- a/libtiff/tif_webp.c
+++ b/libtiff/tif_webp.c
@@ -137,7 +137,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 
     if (sp->read_error)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module,
                       "ZIPDecode: Scanline %" PRIu32 " cannot be read due to "
                       "previous error",
@@ -170,7 +170,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
                              : (uint32_t)tif->tif_rawcc,
                          &webp_width, &webp_height))
         {
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             sp->read_error = 1;
             TIFFErrorExtR(tif, module, "WebPGetInfo() failed");
             return 0;
@@ -178,7 +178,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
         if ((uint32_t)webp_width != segment_width ||
             (uint32_t)webp_height != segment_height)
         {
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             sp->read_error = 1;
             TIFFErrorExtR(
                 tif, module, "WebP blob dimension is %dx%d. Expected %ux%u",
@@ -190,7 +190,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
         WebPDecoderConfig config;
         if (!WebPInitDecoderConfig(&config))
         {
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             sp->read_error = 1;
             TIFFErrorExtR(tif, module, "WebPInitDecoderConfig() failed");
             return 0;
@@ -207,7 +207,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 
         if (!bWebPGetFeaturesOK)
         {
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             sp->read_error = 1;
             TIFFErrorExtR(tif, module, "WebPInitDecoderConfig() failed");
             return 0;
@@ -222,7 +222,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
              */
             !(webp_bands == 3 && sp->nSamples == 4))
         {
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             sp->read_error = 1;
             TIFFErrorExtR(tif, module,
                           "WebP blob band count is %d. Expected %d", webp_bands,
@@ -250,7 +250,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             if (!sp->pBuffer)
             {
                 TIFFErrorExtR(tif, module, "Cannot allocate buffer");
-                memset(op, 0, (size_t)occ);
+                tiff_memset_u8(op, 0, (size_t)occ);
                 sp->read_error = 1;
                 return 0;
             }
@@ -281,7 +281,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 
         if (sp->psDecoder == NULL)
         {
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             sp->read_error = 1;
             TIFFErrorExtR(tif, module, "Unable to allocate WebP decoder.");
             return 0;
@@ -292,7 +292,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
     {
         // read_error not set here as this is a usage issue that can be
         // recovered in a following call.
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         /* Do not set read_error as could potentially be recovered */
         TIFFErrorExtR(tif, module, "Fractional scanlines cannot be read");
         return 0;
@@ -314,7 +314,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
         {
             TIFFErrorExtR(tif, module, "Unrecognized error.");
         }
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         sp->read_error = 1;
         return 0;
     }
@@ -335,7 +335,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             {
                 if (current_y != numberOfExpectedLines)
                 {
-                    memset(op, 0, (size_t)occ);
+                    tiff_memset_u8(op, 0, (size_t)occ);
                     sp->read_error = 1;
                     TIFFErrorExtR(tif, module,
                                   "Unable to decode WebP data: less lines than "
@@ -367,7 +367,7 @@ static int TWebPDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
         }
         else
         {
-            memset(op, 0, (size_t)occ);
+            tiff_memset_u8(op, 0, (size_t)occ);
             sp->read_error = 1;
             TIFFErrorExtR(tif, module, "Unable to decode WebP data.");
             return 0;

--- a/libtiff/tif_zip.c
+++ b/libtiff/tif_zip.c
@@ -200,7 +200,7 @@ static int ZIPDecodeInternal(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 
     if (sp->read_error)
     {
-        memset(op, 0, (size_t)occ);
+        tiff_memset_u8(op, 0, (size_t)occ);
         TIFFErrorExtR(tif, module,
                       "ZIPDecode: Scanline %" PRIu32 " cannot be read due to "
                       "previous error",
@@ -273,7 +273,7 @@ static int ZIPDecodeInternal(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             if (res != LIBDEFLATE_SUCCESS &&
                 res != LIBDEFLATE_INSUFFICIENT_SPACE)
             {
-                memset(op, 0, (size_t)occ);
+                tiff_memset_u8(op, 0, (size_t)occ);
                 TIFFErrorExtR(tif, module, "Decoding error at scanline %lu",
                               (unsigned long)tif->tif_row);
                 sp->read_error = 1;
@@ -308,7 +308,7 @@ static int ZIPDecodeInternal(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
             break;
         if (state == Z_DATA_ERROR)
         {
-            memset(sp->stream.next_out, 0, (size_t)occ);
+            tiff_memset_u8(sp->stream.next_out, 0, (size_t)occ);
             TIFFErrorExtR(tif, module, "Decoding error at scanline %lu, %s",
                           (unsigned long)tif->tif_row, SAFE_MSG(sp));
             sp->read_error = 1;
@@ -316,7 +316,7 @@ static int ZIPDecodeInternal(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
         }
         if (state != Z_OK)
         {
-            memset(sp->stream.next_out, 0, (size_t)occ);
+            tiff_memset_u8(sp->stream.next_out, 0, (size_t)occ);
             TIFFErrorExtR(tif, module, "ZLib error: %s", SAFE_MSG(sp));
             sp->read_error = 1;
             return (0);
@@ -328,7 +328,7 @@ static int ZIPDecodeInternal(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
                       "Not enough data at scanline %lu (short %" PRIu64
                       " bytes)",
                       (unsigned long)tif->tif_row, (uint64_t)occ);
-        memset(sp->stream.next_out, 0, (size_t)occ);
+        tiff_memset_u8(sp->stream.next_out, 0, (size_t)occ);
         sp->read_error = 1;
         return (0);
     }

--- a/libtiff/tif_zstd.c
+++ b/libtiff/tif_zstd.c
@@ -146,7 +146,7 @@ static int ZSTDDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
         zstd_ret = ZSTD_decompressStream(sp->dstream, &out_buffer, &in_buffer);
         if (ZSTD_isError(zstd_ret))
         {
-            memset(op + out_buffer.pos, 0, out_buffer.size - out_buffer.pos);
+            tiff_memset_u8(op + out_buffer.pos, 0, out_buffer.size - out_buffer.pos);
             TIFFErrorExtR(tif, module, "Error in ZSTD_decompressStream(): %s",
                           ZSTD_getErrorName(zstd_ret));
             return 0;
@@ -156,7 +156,7 @@ static int ZSTDDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
 
     if (out_buffer.pos < (size_t)occ)
     {
-        memset(op + out_buffer.pos, 0, out_buffer.size - out_buffer.pos);
+        tiff_memset_u8(op + out_buffer.pos, 0, out_buffer.size - out_buffer.pos);
         TIFFErrorExtR(tif, module,
                       "Not enough data at scanline %lu (short %lu bytes)",
                       (unsigned long)tif->tif_row,

--- a/libtiff/tiff_simd.h
+++ b/libtiff/tiff_simd.h
@@ -153,6 +153,32 @@ extern "C"
         memcpy(dst, src, n);
     }
 
+    static inline void tiff_memset_u8(uint8_t *dst, uint8_t value, size_t n)
+    {
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+        if (tiff_use_neon)
+        {
+            if (n >= 16)
+            {
+                uint8x16_t v = vdupq_n_u8(value);
+                while (((uintptr_t)dst & 15) && n)
+                {
+                    *dst++ = value;
+                    n--;
+                }
+                for (; n >= 16; n -= 16, dst += 16)
+                {
+                    vst1q_u8(dst, v);
+                }
+            }
+            while (n--)
+                *dst++ = value;
+            return;
+        }
+#endif
+        memset(dst, value, n);
+    }
+
     uint32_t tiff_crc32(uint32_t crc, const uint8_t *buf, size_t len);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- accelerate memset with new `tiff_memset_u8` helper
- use the helper in several decoders to zero large buffers

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed171ee288321abd260587a3012b9