### PR TITLE
Allow buffer reuse in NEON strip assembly

### DIFF
--- a/libtiff/strip_neon.h
+++ b/libtiff/strip_neon.h
@@ -13,7 +13,8 @@ extern "C"
     uint8_t *TIFFAssembleStripNEON(TIFF *tif, const uint16_t *src,
                                    uint32_t width, uint32_t height,
                                    int apply_predictor, int bigendian,
-                                   size_t *out_size);
+                                   size_t *out_size, uint16_t *scratch,
+                                   uint8_t *out_buf);
 
 #ifdef __cplusplus
 }

--- a/test/assemble_strip_neon_alloc_fail.c
+++ b/test/assemble_strip_neon_alloc_fail.c
@@ -25,7 +25,8 @@ int main(void)
     setenv("FAIL_MALLOC_COUNT", "1", 1);
     failalloc_reset_from_env();
     uint16_t buf[2] = {0, 0};
-    uint8_t *strip = TIFFAssembleStripNEON(NULL, buf, 1, 2, 0, 1, NULL);
+    uint8_t *strip =
+        TIFFAssembleStripNEON(NULL, buf, 1, 2, 0, 1, NULL, NULL, NULL);
     int ret = 0;
     if (strip != NULL)
     {
@@ -46,7 +47,7 @@ int main(void)
     failalloc_reset_from_env();
     error_buffer[0] = '\0';
     error_module[0] = '\0';
-    strip = TIFFAssembleStripNEON(NULL, buf, 1, 2, 0, 1, NULL);
+    strip = TIFFAssembleStripNEON(NULL, buf, 1, 2, 0, 1, NULL, NULL, NULL);
     if (strip != NULL)
     {
         fprintf(stderr, "Expected failure on second allocation\n");
@@ -67,15 +68,16 @@ int main(void)
     /* Overflow detection */
     error_buffer[0] = '\0';
     error_module[0] = '\0';
-    strip =
-        TIFFAssembleStripNEON(NULL, buf, 0xFFFFFFFFU, 0xFFFFFFFFU, 0, 1, NULL);
+    strip = TIFFAssembleStripNEON(NULL, buf, 0xFFFFFFFFU, 0xFFFFFFFFU, 0, 1,
+                                  NULL, NULL, NULL);
     if (strip != NULL)
     {
         fprintf(stderr, "Expected overflow failure\n");
         free(strip);
         ret = 1;
     }
-    if (strcmp(error_buffer, "Integer overflow in TIFFAssembleStripNEON") != 0 ||
+    if (strcmp(error_buffer, "Integer overflow in TIFFAssembleStripNEON") !=
+            0 ||
         strcmp(error_module, "TIFFAssembleStripNEON") != 0)
     {
         fprintf(stderr, "Unexpected error: %s (%s)\n", error_module,

--- a/test/assemble_strip_neon_test.c
+++ b/test/assemble_strip_neon_test.c
@@ -16,8 +16,8 @@ int main(void)
         buf[i] = (uint16_t)i;
 
     size_t strip_size = 0;
-    uint8_t *strip =
-        TIFFAssembleStripNEON(NULL, buf, width, height, 0, 1, &strip_size);
+    uint8_t *strip = TIFFAssembleStripNEON(NULL, buf, width, height, 0, 1,
+                                           &strip_size, NULL, NULL);
     free(buf);
     if (!strip)
         return 1;

--- a/test/pack_uring_benchmark.c
+++ b/test/pack_uring_benchmark.c
@@ -24,8 +24,8 @@ int main(void)
         src[i] = (uint16_t)(i & 0x0FFF);
 
     size_t strip_size = 0;
-    uint8_t *packed =
-        TIFFAssembleStripNEON(NULL, src, width, height, 1, 0, &strip_size);
+    uint8_t *packed = TIFFAssembleStripNEON(NULL, src, width, height, 1, 0,
+                                            &strip_size, NULL, NULL);
 
     struct timespec s, e;
     clock_gettime(CLOCK_MONOTONIC, &s);

--- a/test/predictor_threadpool_benchmark.c
+++ b/test/predictor_threadpool_benchmark.c
@@ -26,7 +26,7 @@ static void bench_task(void *arg)
     {
         size_t out_size = 0;
         uint8_t *dst = TIFFAssembleStripNEON(NULL, t->src, t->width, t->height,
-                                             1, 0, &out_size);
+                                             1, 0, &out_size, NULL, NULL);
         if (!dst)
             continue;
 #ifdef USE_IO_URING

--- a/test/predictor_threadpool_resize.c
+++ b/test/predictor_threadpool_resize.c
@@ -21,7 +21,7 @@ static void bench_task(void *arg)
     {
         size_t out_size = 0;
         uint8_t *dst = TIFFAssembleStripNEON(NULL, t->src, t->width, t->height,
-                                             1, 0, &out_size);
+                                             1, 0, &out_size, NULL, NULL);
         free(dst);
     }
 }


### PR DESCRIPTION
## Summary
- update TIFFAssembleStripNEON to accept caller-provided scratch/output buffers
- skip memcpy when no predictor is applied
- update README examples
- adjust tests to new API

## Testing
- `pre-commit run --files libtiff/tif_strip_neon.c libtiff/strip_neon.h README.md test/assemble_strip_neon_test.c test/assemble_strip_neon_alloc_fail.c test/predictor_threadpool_benchmark.c test/predictor_threadpool_resize.c test/pack_uring_benchmark.c`
- ❌ `cmake --build .` *(fails: unknown type name 'uint32x4_t' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684edf41164c832181e892fbe29ea4a1