### PR TITLE
Add thread-based async I/O fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ free(tmp);
 free(buf);
 ```
 
-When io_uring is enabled you may queue each strip using `_tiffUringWriteProc`
-while preparing the next one.  After the thread pool finishes assembling
-strips call `_tiffUringWait` to flush outstanding writes:
+When asynchronous I/O is enabled you may queue each strip using
+`_tiffUringWriteProc` while preparing the next one. After the thread pool
+finishes assembling strips call `_tiffUringWait` to flush outstanding writes:
 
 ```c
 _tiffUringSetAsync(tif, 1);
@@ -334,11 +334,13 @@ submit work items to this pool when more than one thread is available.
 ## io_uring Configuration
 
 io_uring support requires Linux 5.1 and liburing. Enable it with
-`-Dio-uring=ON` (CMake) or `--enable-io-uring` (Autotools). The queue depth
-defaults to 8 but may be tuned through the `TIFF_URING_DEPTH` environment
-variable, via `TIFFOpenOptionsSetURingQueueDepth()` before opening a file, or at
-runtime with `TIFFSetURingQueueDepth()`. Any positive value accepted by the
-kernel is allowed.
+`-Dio-uring=ON` (CMake) or `--enable-io-uring` (Autotools). When unavailable,
+the library falls back to a portable thread-based helper that shares the same
+API. The queue depth defaults to 8 but may be tuned through the
+`TIFF_URING_DEPTH` environment variable, via
+`TIFFOpenOptionsSetURingQueueDepth()` before opening a file, or at runtime with
+`TIFFSetURingQueueDepth()`. Any positive value accepted by the kernel is
+allowed.
 
 ## Memory Mapping Tuning
 

--- a/libtiff/CMakeLists.txt
+++ b/libtiff/CMakeLists.txt
@@ -126,8 +126,8 @@ else()
   set_property(SOURCE tif_unix.c APPEND PROPERTY COMPILE_DEFINITIONS ALLOW_TIFF_NON_EXT_ALLOC_FUNCTIONS)
 endif()
 
+target_sources(tiff PRIVATE tif_uring.c)
 if(USE_IO_URING)
-  target_sources(tiff PRIVATE tif_uring.c)
   target_link_libraries(tiff PRIVATE ${IOURING_LIBRARY})
 endif()
 

--- a/libtiff/Makefile.am
+++ b/libtiff/Makefile.am
@@ -107,6 +107,7 @@ libtiff_la_SOURCES = \
         tif_bayer.c \
         tif_rgb.c \
         tif_write.c \
+        tif_uring.c \
         tiff_threadpool.c \
         tif_mmap.c \
         tif_zip.c \

--- a/libtiff/tif_close.c
+++ b/libtiff/tif_close.c
@@ -52,9 +52,7 @@ void TIFFCleanup(TIFF *tif)
     _TIFFCleanupCustomValueMap(&tif->tif_dir);
 
     _TIFFCleanupIFDOffsetAndNumberMaps(tif);
-#ifdef USE_IO_URING
     _tiffUringTeardown(tif);
-#endif
 
     /*
      * Clean up client info links.

--- a/libtiff/tif_open.c
+++ b/libtiff/tif_open.c
@@ -134,12 +134,11 @@ void TIFFOpenOptionsSetWarningHandlerExtR(TIFFOpenOptions *opts,
     opts->warnhandler_user_data = warnhandler_user_data;
 }
 
-#ifdef USE_IO_URING
-void TIFFOpenOptionsSetURingQueueDepth(TIFFOpenOptions *opts, unsigned int depth)
+void TIFFOpenOptionsSetURingQueueDepth(TIFFOpenOptions *opts,
+                                       unsigned int depth)
 {
     opts->uring_queue_depth = depth;
 }
-#endif
 
 static void _TIFFEmitErrorAboveMaxSingleMemAlloc(TIFF *tif,
                                                  const char *pszFunction,
@@ -293,8 +292,7 @@ void _TIFFfreeExt(TIFF *tif, void *p)
         memcpy(&oldSize, oldPtr, sizeof(oldSize));
         if (oldSize <= 0 || oldSize > tif->tif_cur_cumulated_mem_alloc)
         {
-            TIFFErrorExtR(tif, "_TIFFfreeExt",
-                          "Corrupt size header in buffer");
+            TIFFErrorExtR(tif, "_TIFFfreeExt", "Corrupt size header in buffer");
             return;
         }
         tif->tif_cur_cumulated_mem_alloc -= oldSize;
@@ -353,8 +351,7 @@ TIFF *TIFFClientOpenExt(const char *name, const char *mode,
         if (n.a16 != 1)
 #endif
         {
-            TIFFErrorExtR(NULL, module,
-                          "Unexpected byte order configuration");
+            TIFFErrorExtR(NULL, module, "Unexpected byte order configuration");
             goto bad2;
         }
     }
@@ -418,9 +415,7 @@ TIFF *TIFFClientOpenExt(const char *name, const char *mode,
         tif->tif_max_single_mem_alloc = opts->max_single_mem_alloc;
         tif->tif_max_cumulated_mem_alloc = opts->max_cumulated_mem_alloc;
         tif->tif_warn_about_unknown_tags = opts->warn_about_unknown_tags;
-#ifdef USE_IO_URING
         tif->tif_uring_depth = opts->uring_queue_depth;
-#endif
     }
 
     if (!readproc || !writeproc || !seekproc || !closeproc || !sizeproc)

--- a/libtiff/tif_uring.c
+++ b/libtiff/tif_uring.c
@@ -1,11 +1,18 @@
 #include "tif_config.h"
-#ifdef USE_IO_URING
 #include "tiffiop.h"
 #include <errno.h>
-#include <liburing.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <sys/uio.h>
+#ifdef USE_IO_URING
+#include <liburing.h>
+#else
+#include "tiff_threadpool.h"
+
+#include <unistd.h>
+#endif
+
+#ifdef USE_IO_URING
 
 /*
  * io_uring based asynchronous I/O helpers.  The API became stable in
@@ -276,6 +283,252 @@ tmsize_t _tiffUringWriteV(thandle_t fd, struct iovec *iov, unsigned int iovcnt,
                           tmsize_t size)
 {
     return io_uring_rw(0, fd, iov, iovcnt, size);
+}
+
+#else /* USE_IO_URING */
+
+/* Thread-based asynchronous I/O fallback */
+
+typedef struct _TIFFURingEntry
+{
+    int fd;
+    TIFFThreadPool *pool;
+    int async;
+    int pending;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    struct _TIFFURingEntry *next;
+} _TIFFURingEntry;
+
+static _TIFFURingEntry *gUringList = NULL;
+static pthread_mutex_t gUringMutex = PTHREAD_MUTEX_INITIALIZER;
+
+static _TIFFURingEntry *_tiffUringFind(int fd)
+{
+    _TIFFURingEntry *cur;
+    for (cur = gUringList; cur; cur = cur->next)
+    {
+        if (cur->fd == fd)
+            return cur;
+    }
+    return NULL;
+}
+
+static int _tiffUringAdd(TIFF *tif, int fd)
+{
+    pthread_mutex_lock(&gUringMutex);
+    if (_tiffUringFind(fd))
+    {
+        pthread_mutex_unlock(&gUringMutex);
+        TIFFErrorExtR(tif, "tif_uring", "fd %d already registered", fd);
+        return 0;
+    }
+
+    _TIFFURingEntry *e = (_TIFFURingEntry *)_TIFFmallocExt(tif, sizeof(*e));
+    if (!e)
+    {
+        pthread_mutex_unlock(&gUringMutex);
+        TIFFErrorExtR(tif, "tif_uring", "Out of memory allocating ring entry");
+        return 0;
+    }
+    e->fd = fd;
+    unsigned int workers = tif->tif_uring_depth > 0 ? tif->tif_uring_depth : 1;
+    e->pool = _TIFFThreadPoolInit((int)workers);
+    if (!e->pool)
+    {
+        pthread_mutex_unlock(&gUringMutex);
+        _TIFFfreeExt(tif, e);
+        TIFFErrorExtR(tif, "tif_uring", "Thread pool init failed");
+        return 0;
+    }
+    e->async = 0;
+    e->pending = 0;
+    pthread_mutex_init(&e->mutex, NULL);
+    pthread_cond_init(&e->cond, NULL);
+    e->next = gUringList;
+    gUringList = e;
+    pthread_mutex_unlock(&gUringMutex);
+    return 1;
+}
+
+static void _tiffUringRemove(int fd)
+{
+    pthread_mutex_lock(&gUringMutex);
+    _TIFFURingEntry **pp = &gUringList;
+    while (*pp)
+    {
+        if ((*pp)->fd == fd)
+        {
+            _TIFFURingEntry *tmp = *pp;
+            *pp = tmp->next;
+            pthread_mutex_unlock(&gUringMutex);
+            _TIFFThreadPoolShutdown(tmp->pool);
+            pthread_mutex_destroy(&tmp->mutex);
+            pthread_cond_destroy(&tmp->cond);
+            _TIFFfreeExt(NULL, tmp);
+            return;
+        }
+        pp = &(*pp)->next;
+    }
+    pthread_mutex_unlock(&gUringMutex);
+}
+
+int _tiffUringInit(TIFF *tif)
+{
+    if (!_tiffUringAdd(tif, tif->tif_fd))
+        return 0;
+    tif->tif_uring = _tiffUringFind(tif->tif_fd);
+    tif->tif_uring_async = 0;
+    return tif->tif_uring != NULL;
+}
+
+void _tiffUringTeardown(TIFF *tif)
+{
+    if (!tif || !tif->tif_uring)
+        return;
+    _tiffUringWait(tif);
+    _tiffUringRemove(tif->tif_fd);
+    tif->tif_uring = NULL;
+}
+
+void _tiffUringSetAsync(TIFF *tif, int enable)
+{
+    if (!tif || !tif->tif_uring)
+        return;
+    _TIFFURingEntry *e = (_TIFFURingEntry *)tif->tif_uring;
+    pthread_mutex_lock(&e->mutex);
+    e->async = enable ? 1 : 0;
+    pthread_mutex_unlock(&e->mutex);
+    tif->tif_uring_async = enable ? 1 : 0;
+}
+
+void _tiffUringFlush(TIFF *tif) { (void)tif; }
+
+void _tiffUringWait(TIFF *tif)
+{
+    if (!tif || !tif->tif_uring)
+        return;
+    _TIFFURingEntry *e = (_TIFFURingEntry *)tif->tif_uring;
+    pthread_mutex_lock(&e->mutex);
+    while (e->pending > 0)
+        pthread_cond_wait(&e->cond, &e->mutex);
+    pthread_mutex_unlock(&e->mutex);
+}
+
+int TIFFSetURingQueueDepth(TIFF *tif, unsigned int depth)
+{
+    if (!tif)
+        return 0;
+    tif->tif_uring_depth = depth;
+    return 1;
+}
+
+unsigned int TIFFGetURingQueueDepth(TIFF *tif)
+{
+    if (!tif)
+        return 0;
+    return tif->tif_uring_depth;
+}
+
+struct _aio_task
+{
+    _TIFFURingEntry *e;
+    int readflag;
+    thandle_t fd;
+    struct iovec *iov;
+    unsigned int iovcnt;
+};
+
+static void _aio_worker(void *arg)
+{
+    struct _aio_task *t = (struct _aio_task *)arg;
+    if (t->readflag)
+        readv((int)(intptr_t)t->fd, t->iov, t->iovcnt);
+    else
+        writev((int)(intptr_t)t->fd, t->iov, t->iovcnt);
+    pthread_mutex_lock(&t->e->mutex);
+    t->e->pending--;
+    if (t->e->pending == 0)
+        pthread_cond_broadcast(&t->e->cond);
+    pthread_mutex_unlock(&t->e->mutex);
+    _TIFFfreeExt(NULL, t->iov);
+    _TIFFfreeExt(NULL, t);
+}
+
+static tmsize_t aio_rw(int readflag, thandle_t fd, struct iovec *iov,
+                       unsigned int iovcnt, tmsize_t total_size)
+{
+    pthread_mutex_lock(&gUringMutex);
+    _TIFFURingEntry *e = _tiffUringFind((int)(intptr_t)fd);
+    pthread_mutex_unlock(&gUringMutex);
+    if (!e)
+        return (tmsize_t)-1;
+
+    if (!e->async)
+    {
+        ssize_t ret = readflag ? readv((int)(intptr_t)fd, iov, iovcnt)
+                               : writev((int)(intptr_t)fd, iov, iovcnt);
+        return ret < 0 ? (tmsize_t)-1 : (tmsize_t)ret;
+    }
+
+    struct _aio_task *task =
+        (struct _aio_task *)_TIFFmallocExt(NULL, sizeof(struct _aio_task));
+    if (!task)
+        return (tmsize_t)-1;
+    struct iovec *iov_copy =
+        (struct iovec *)_TIFFmallocExt(NULL, sizeof(struct iovec) * iovcnt);
+    if (!iov_copy)
+    {
+        _TIFFfreeExt(NULL, task);
+        return (tmsize_t)-1;
+    }
+    memcpy(iov_copy, iov, sizeof(struct iovec) * iovcnt);
+    task->e = e;
+    task->readflag = readflag;
+    task->fd = fd;
+    task->iov = iov_copy;
+    task->iovcnt = iovcnt;
+
+    pthread_mutex_lock(&e->mutex);
+    e->pending++;
+    pthread_mutex_unlock(&e->mutex);
+
+    if (!_TIFFThreadPoolSubmit(e->pool, _aio_worker, task))
+    {
+        pthread_mutex_lock(&e->mutex);
+        e->pending--;
+        if (e->pending == 0)
+            pthread_cond_broadcast(&e->cond);
+        pthread_mutex_unlock(&e->mutex);
+        _TIFFfreeExt(NULL, iov_copy);
+        _TIFFfreeExt(NULL, task);
+        return (tmsize_t)-1;
+    }
+    return total_size;
+}
+
+tmsize_t _tiffUringReadProc(thandle_t fd, void *buf, tmsize_t size)
+{
+    struct iovec iov = {buf, (size_t)size};
+    return aio_rw(1, fd, &iov, 1, size);
+}
+
+tmsize_t _tiffUringWriteProc(thandle_t fd, void *buf, tmsize_t size)
+{
+    struct iovec iov = {buf, (size_t)size};
+    return aio_rw(0, fd, &iov, 1, size);
+}
+
+tmsize_t _tiffUringReadV(thandle_t fd, struct iovec *iov, unsigned int iovcnt,
+                         tmsize_t size)
+{
+    return aio_rw(1, fd, iov, iovcnt, size);
+}
+
+tmsize_t _tiffUringWriteV(thandle_t fd, struct iovec *iov, unsigned int iovcnt,
+                          tmsize_t size)
+{
+    return aio_rw(0, fd, iov, iovcnt, size);
 }
 
 #endif /* USE_IO_URING */

--- a/libtiff/tiffio.h
+++ b/libtiff/tiffio.h
@@ -533,10 +533,8 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
     TIFFOpenOptionsSetWarningHandlerExtR(TIFFOpenOptions *opts,
                                          TIFFErrorHandlerExtR handler,
                                          void *warnhandler_user_data);
-#ifdef USE_IO_URING
     extern void TIFFOpenOptionsSetURingQueueDepth(TIFFOpenOptions *opts,
                                                   unsigned int depth);
-#endif
 
     extern TIFF *TIFFOpen(const char *, const char *);
     extern TIFF *TIFFOpenExt(const char *, const char *, TIFFOpenOptions *opts);
@@ -581,10 +579,8 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
     extern void TIFFSetUseSSE41(int);
     extern void TIFFSetMapSize(tmsize_t size);
     extern void TIFFSetMapAdvice(int fadvise_flags, int madvise_flags);
-#ifdef USE_IO_URING
     extern int TIFFSetURingQueueDepth(TIFF *tif, unsigned int depth);
     extern unsigned int TIFFGetURingQueueDepth(TIFF *tif);
-#endif
     extern tmsize_t TIFFReadEncodedStrip(TIFF *tif, uint32_t strip, void *buf,
                                          tmsize_t size);
     extern tmsize_t TIFFReadRawStrip(TIFF *tif, uint32_t strip, void *buf,


### PR DESCRIPTION
## Summary
- allow using async I/O helpers without io_uring
- compile tif_uring.c on all builds
- queue writes via portable worker threads when io_uring is absent
- document the fallback and update prototypes

## Testing
- `pre-commit run --files README.md libtiff/CMakeLists.txt libtiff/Makefile.am libtiff/tif_close.c libtiff/tif_open.c libtiff/tif_unix.c libtiff/tif_uring.c libtiff/tiffio.h libtiff/tiffiop.h`
- `cmake ..` *(fails: missing CharLS and build requirements)*

------
https://chatgpt.com/codex/tasks/task_e_684ee74e20d88321af1fbc1df8669292