### PR TITLE
Fix tiff_memset_u8 linkage

### DIFF
--- a/libtiff/tif_fax3.c
+++ b/libtiff/tif_fax3.c
@@ -23,6 +23,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #ifdef CCITT_SUPPORT
 /*
  * TIFF Library.

--- a/libtiff/tif_jbig.c
+++ b/libtiff/tif_jbig.c
@@ -31,6 +31,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 
 #ifdef JBIG_SUPPORT
 #include "jbig.h"

--- a/libtiff/tif_lzma.c
+++ b/libtiff/tif_lzma.c
@@ -22,6 +22,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #ifdef LZMA_SUPPORT
 /*
  * TIFF Library.

--- a/libtiff/tif_lzw.c
+++ b/libtiff/tif_lzw.c
@@ -24,6 +24,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #ifdef LZW_SUPPORT
 /*
  * TIFF Library.

--- a/libtiff/tif_packbits.c
+++ b/libtiff/tif_packbits.c
@@ -23,6 +23,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #ifdef PACKBITS_SUPPORT
 /*
  * TIFF Library.

--- a/libtiff/tif_pixarlog.c
+++ b/libtiff/tif_pixarlog.c
@@ -23,6 +23,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #ifdef PIXARLOG_SUPPORT
 
 /*

--- a/libtiff/tif_thunder.c
+++ b/libtiff/tif_thunder.c
@@ -23,6 +23,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #include <assert.h>
 #ifdef THUNDER_SUPPORT
 /*

--- a/libtiff/tif_webp.c
+++ b/libtiff/tif_webp.c
@@ -23,6 +23,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #ifdef WEBP_SUPPORT
 /*
  * TIFF Library.

--- a/libtiff/tif_zstd.c
+++ b/libtiff/tif_zstd.c
@@ -23,6 +23,7 @@
  */
 
 #include "tiffiop.h"
+#include "tiff_simd.h"
 #ifdef ZSTD_SUPPORT
 /*
  * TIFF Library.


### PR DESCRIPTION
## Summary
- include `tiff_simd.h` alongside `tiffiop.h` in multiple codec files
- verify build succeeds

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-lzw-single-strip, tiffcrop-extract-testfax4, tiffcrop-extract-testfax3_bug_513, tiffcrop-extract-32bpp-None, tiffcrop-extractz14-custom_dir_EXIF_GPS, and others)*

------
https://chatgpt.com/codex/tasks/task_e_684ef554ee448321b070e512314dfde2