### PR TITLE
Convert addtiffo resampling option to enum

### DIFF
--- a/TODO_issues.md
+++ b/TODO_issues.md
@@ -7,8 +7,7 @@ This document lists the TODO comments found throughout the repository as of this
 
 ## contrib/addtiffo
 - **addtiffo.c**: un-hardwire array length for `anOverviews` (line 77) **[!]**
-- **addtiffo.c**: encode resampling mode parameter as an integer (line 118).
-- **addtiffo.c**: default overview levels based on source image size (line 140).
+- **addtiffo.c**: default overview levels based on source image size (line 160).
 - **tif_overview.c**: update header notes (line 48).
 - **tif_overview.c**: write `YCbCrPositioning` and `YCbCrCoefficients` tags (line 132).
 - **tif_overview.c**: add parameter for JPEG compression quality (line 135).

--- a/contrib/addtiffo/README
+++ b/contrib/addtiffo/README
@@ -19,7 +19,7 @@ http://home.gdal.org/~warmerda/
 Usage
 -----
 
-Usage: addtiffo [-r {average/nearest} [-subifd] 
+Usage: addtiffo [-r {nearest,average,mode}] [-subifd]
                 tiff_filename [resolution_reductions]
 
 Example:

--- a/contrib/addtiffo/tif_overview.c
+++ b/contrib/addtiffo/tif_overview.c
@@ -67,7 +67,7 @@
 
 #define TIFF_DIR_MAX 65534
 
-void TIFFBuildOverviews(TIFF *, int, int *, int, const char *,
+void TIFFBuildOverviews(TIFF *, int, int *, int, OVRResampleMethod,
                         int (*)(double, void *), void *);
 
 /************************************************************************/
@@ -272,7 +272,7 @@ static void TIFF_DownSample(unsigned char *pabySrcTile, uint32_t nBlockXSize,
                             int nBitsPerPixel, unsigned char *pabyOTile,
                             uint32_t nOBlockXSize, uint32_t nOBlockYSize,
                             uint32_t nTXOff, uint32_t nTYOff, int nOMult,
-                            int nSampleFormat, const char *pszResampling)
+                            int nSampleFormat, OVRResampleMethod eResampling)
 
 {
     uint32_t i, j;
@@ -324,8 +324,7 @@ static void TIFF_DownSample(unsigned char *pabySrcTile, uint32_t nBlockXSize,
         /*      data type, we just do a bytewise copy. */
         /* --------------------------------------------------------------------
          */
-        if (strncmp(pszResampling, "nearest", 4) == 0 ||
-            strncmp(pszResampling, "NEAR", 4) == 0)
+        if (eResampling == OVR_RESAMPLE_NEAREST)
         {
             pabySrc = pabySrcTile + j * nOMult * nBlockXSize * nPixelGroupBytes;
 
@@ -353,8 +352,7 @@ static void TIFF_DownSample(unsigned char *pabySrcTile, uint32_t nBlockXSize,
         /*      handle each sample format we are concerned with. */
         /* --------------------------------------------------------------------
          */
-        else if (strncmp(pszResampling, "averag", 6) == 0 ||
-                 strncmp(pszResampling, "AVERAG", 6) == 0)
+        else if (eResampling == OVR_RESAMPLE_AVERAGE)
         {
             pabySrc = pabySrcTile + j * nOMult * nBlockXSize * nPixelGroupBytes;
 
@@ -398,7 +396,7 @@ static void TIFF_DownSample_Subsampled(
     unsigned char *pabySrcTile, int nSample, uint32_t nBlockXSize,
     uint32_t nBlockYSize, unsigned char *pabyOTile, uint32_t nOBlockXSize,
     uint32_t nOBlockYSize, uint32_t nTXOff, uint32_t nTYOff, int nOMult,
-    const char *pszResampling, int nHorSubsampling, int nVerSubsampling)
+    OVRResampleMethod eResampling, int nHorSubsampling, int nVerSubsampling)
 {
     /* TODO: test with variety of subsampling values, and incovinient tile/strip
      * sizes */
@@ -421,8 +419,7 @@ static void TIFF_DownSample_Subsampled(
         ((nOBlockXSize + nHorSubsampling - 1) / nHorSubsampling) *
         nSampleBlockSize;
 
-    if (strncmp(pszResampling, "nearest", 4) == 0 ||
-        strncmp(pszResampling, "NEAR", 4) == 0)
+    if (eResampling == OVR_RESAMPLE_NEAREST)
     {
         if (nSample == 0)
         {
@@ -478,8 +475,7 @@ static void TIFF_DownSample_Subsampled(
             }
         }
     }
-    else if (strncmp(pszResampling, "averag", 6) == 0 ||
-             strncmp(pszResampling, "AVERAG", 6) == 0)
+    else if (eResampling == OVR_RESAMPLE_AVERAGE)
     {
         if (nSample == 0)
         {
@@ -594,7 +590,7 @@ void TIFF_ProcessFullResBlock(TIFF *hTIFF, int nPlanarConfig, int bSubsampled,
                               uint32_t nSXOff, uint32_t nSYOff,
                               unsigned char *pabySrcTile, uint32_t nBlockXSize,
                               uint32_t nBlockYSize, int nSampleFormat,
-                              const char *pszResampling)
+                              OVRResampleMethod eResampling)
 
 {
     int iOverview, iSample;
@@ -661,7 +657,7 @@ void TIFF_ProcessFullResBlock(TIFF *hTIFF, int nPlanarConfig, int bSubsampled,
                 TIFF_DownSample_Subsampled(
                     pabySrcTile, iSample, nBlockXSize, nBlockYSize, pabyOTile,
                     poRBI->nBlockXSize, poRBI->nBlockYSize, nTXOff, nTYOff,
-                    nOMult, pszResampling, nHorSubsampling, nVerSubsampling);
+                    nOMult, eResampling, nHorSubsampling, nVerSubsampling);
 #ifdef DBMALLOC
                 malloc_chain_check(1);
 #endif
@@ -704,7 +700,7 @@ void TIFF_ProcessFullResBlock(TIFF *hTIFF, int nPlanarConfig, int bSubsampled,
                                 nBlockYSize, nSkewBits, nBitsPerPixel,
                                 pabyOTile, poRBI->nBlockXSize,
                                 poRBI->nBlockYSize, nTXOff, nTYOff, nOMult,
-                                nSampleFormat, pszResampling);
+                                nSampleFormat, eResampling);
 #ifdef DBMALLOC
                 malloc_chain_check(1);
 #endif
@@ -724,7 +720,7 @@ void TIFF_ProcessFullResBlock(TIFF *hTIFF, int nPlanarConfig, int bSubsampled,
 /************************************************************************/
 
 void TIFFBuildOverviews(TIFF *hTIFF, int nOverviews, int *panOvList,
-                        int bUseSubIFDs, const char *pszResampleMethod,
+                        int bUseSubIFDs, OVRResampleMethod eResampleMethod,
                         int (*pfnProgress)(double, void *), void *pProgressData)
 
 {
@@ -912,7 +908,7 @@ void TIFFBuildOverviews(TIFF *hTIFF, int nOverviews, int *panOvList,
                 hTIFF, nPlanarConfig, bSubsampled, nHorSubsampling,
                 nVerSubsampling, nOverviews, panOvList, nBitsPerPixel, nSamples,
                 papoRawBIs, nSXOff, nSYOff, pabySrcTile, nBlockXSize,
-                nBlockYSize, nSampleFormat, pszResampleMethod);
+                nBlockYSize, nSampleFormat, eResampleMethod);
         }
     }
 

--- a/contrib/addtiffo/tif_ovrcache.h
+++ b/contrib/addtiffo/tif_ovrcache.h
@@ -75,13 +75,20 @@ extern "C"
                                               int iTileY);
     void TIFFDestroyOvrCache(TIFFOvrCache *);
 
-    void TIFFBuildOverviews(TIFF *, int, int *, int, const char *,
+    typedef enum
+    {
+        OVR_RESAMPLE_NEAREST = 0,
+        OVR_RESAMPLE_AVERAGE = 1,
+        OVR_RESAMPLE_MODE = 2
+    } OVRResampleMethod;
+
+    void TIFFBuildOverviews(TIFF *, int, int *, int, OVRResampleMethod,
                             int (*)(double, void *), void *);
 
     void TIFF_ProcessFullResBlock(TIFF *, int, int, int, int, int, int *, int,
                                   int, TIFFOvrCache **, uint32_t, uint32_t,
                                   unsigned char *, uint32_t, uint32_t, int,
-                                  const char *);
+                                  OVRResampleMethod);
 
     uint32_t TIFF_WriteOverview(TIFF *, uint32_t, uint32_t, int, int, int, int,
                                 int, int, int, int, int, unsigned short *,


### PR DESCRIPTION
## Summary
- add resampling enum in `tif_ovrcache.h`
- parse resampling modes into enum in `addtiffo.c`
- update overview builder to use enum
- document enum-based option in README
- update TODO list

## Testing
- `cmake --build . --target addtiffo`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-lzw-single-strip, tiffcrop-extract-testfax4, tiffcrop-extract-testfax3_bug_513, tiffcrop-extract-32bpp-None, tiffcrop-extractz14-custom_dir_EXIF_GPS, tiffcrop-extractz14-logluv-3c-16b, tiffcrop-extractz14-minisblack-1c-16b, tiffcrop-extractz14-minisblack-1c-8b, tiffcrop-extractz14-minisblack-2c-8b-alpha, tiffcrop-extractz14-miniswhite-1c-1b, tiffcrop-extractz14-palette-1c-1b, tiffcrop-extractz14-palette-1c-4b, tiffcrop-extractz14-palette-1c-8b, tiffcrop-extractz14-rgb-3c-16b, tiffcrop-extractz14-rgb-3c-8b, tiffcrop-extractz14-quad-lzw-compat, tiffcrop-extractz14-lzw-single-strip, tiffcrop-extractz14-testfax4, tiffcrop-extractz14-testfax3_bug_513, tiffcrop-extractz14-32bpp-None)*

------
https://chatgpt.com/codex/tasks/task_e_684f05d6c8988321a7c4f300b4842153