### PR TITLE
Compute addtiffo overview levels from image size

### DIFF
--- a/test/AddtiffoTest.cmake
+++ b/test/AddtiffoTest.cmake
@@ -1,0 +1,28 @@
+include(${CMAKE_CURRENT_LIST_DIR}/TiffTestCommon.cmake)
+
+get_filename_component(_src "${IMAGE}" ABSOLUTE)
+get_filename_component(_name "${IMAGE}" NAME)
+set(_dst "${OUTDIR}/${_name}")
+file(COPY "${_src}" DESTINATION "${OUTDIR}")
+
+message(STATUS "Running ${ADDTIFFO} ${_dst}")
+execute_process(COMMAND ${ADDTIFFO} ${_dst} RESULT_VARIABLE _rv)
+if(_rv)
+  message(FATAL_ERROR "addtiffo failed")
+endif()
+
+execute_process(COMMAND ${TIFFINFO} -D ${_dst} OUTPUT_VARIABLE _info RESULT_VARIABLE _rv)
+if(_rv)
+  message(FATAL_ERROR "tiffinfo failed")
+endif()
+string(REGEX MATCHCOUNT "Directory" _count "${_info}")
+if(EXPECT_GT1)
+  if(_count LESS 2)
+    message(FATAL_ERROR "Expected more than one directory, got ${_count}")
+  endif()
+else()
+  if(NOT _count EQUAL 1)
+    message(FATAL_ERROR "Expected one directory, got ${_count}")
+  endif()
+endif()
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -383,6 +383,9 @@ if(tiff-tools)
   list(APPEND tiff_test_extra_args "-DTIFFCP=$<TARGET_FILE:tiffcp>")
   list(APPEND tiff_test_extra_args "-DTIFFINFO=$<TARGET_FILE:tiffinfo>")
   list(APPEND tiff_test_extra_args "-DTIFFSPLIT=$<TARGET_FILE:tiffsplit>")
+  if(tiff-contrib)
+    list(APPEND tiff_test_extra_args "-DADDTIFFO=$<TARGET_FILE:addtiffo>")
+  endif()
 endif()
 
 if(WIN32)
@@ -658,4 +661,21 @@ if(tiff-tools)
   add_convert_tests(tiffcrop  extract    "-U px -E top -X 60 -Y 60" TIFFIMAGES TRUE)
   # Test extracting the first and fourth quarters from the left side.
   add_convert_tests(tiffcrop  extractz14 "-E left -Z1:4,2:4"        TIFFIMAGES TRUE)
+
+  # addtiffo default overview levels
+  add_test(NAME "addtiffo-default-small"
+           COMMAND "${CMAKE_COMMAND}"
+           "-DIMAGE=${CMAKE_CURRENT_SOURCE_DIR}/images/rgb-3c-8b.tiff"
+           "-DEXPECT_GT1=FALSE"
+           "-DOUTDIR=${TEST_OUTPUT}"
+           ${tiff_test_extra_args}
+           -P "${CMAKE_CURRENT_SOURCE_DIR}/AddtiffoTest.cmake")
+
+  add_test(NAME "addtiffo-default-large"
+           COMMAND "${CMAKE_COMMAND}"
+           "-DIMAGE=${CMAKE_CURRENT_SOURCE_DIR}/images/lzw-single-strip.tiff"
+           "-DEXPECT_GT1=TRUE"
+           "-DOUTDIR=${TEST_OUTPUT}"
+           ${tiff_test_extra_args}
+           -P "${CMAKE_CURRENT_SOURCE_DIR}/AddtiffoTest.cmake")
 endif()


### PR DESCRIPTION
## Summary
- compute default overview levels in `addtiffo` from the input image
- expose addtiffo path to tests and add simple cmake test helper
- add regression tests for small and large images

## Testing
- `pre-commit run --files contrib/addtiffo/addtiffo.c test/CMakeLists.txt test/AddtiffoTest.cmake`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure` *(fails: addtiffo-default-small, addtiffo-default-large, plus many others)*

------
https://chatgpt.com/codex/tasks/task_e_684f08286be48321a704efa6d9f5c907