### PR TITLE
Add YCbCr tags in overview writing

### DIFF
--- a/contrib/addtiffo/tif_overview.c
+++ b/contrib/addtiffo/tif_overview.c
@@ -95,8 +95,17 @@ uint32_t TIFF_WriteOverview(TIFF *hTIFF, uint32_t nXSize, uint32_t nYSize,
     toff_t nBaseDirOffset;
     toff_t nOffset;
     tdir_t iNumDir;
+    uint16_t nYCbCrPositioning = 0;
+    const float *pfYCbCrCoeffs = NULL;
 
     (void)bUseSubIFDs;
+
+    if (nPhotometric == PHOTOMETRIC_YCBCR || nPhotometric == PHOTOMETRIC_ITULAB)
+    {
+        TIFFGetFieldDefaulted(hTIFF, TIFFTAG_YCBCRPOSITIONING,
+                              &nYCbCrPositioning);
+        TIFFGetFieldDefaulted(hTIFF, TIFFTAG_YCBCRCOEFFICIENTS, &pfYCbCrCoeffs);
+    }
 
     nBaseDirOffset = TIFFCurrentDirOffset(hTIFF);
 
@@ -132,8 +141,9 @@ uint32_t TIFF_WriteOverview(TIFF *hTIFF, uint32_t nXSize, uint32_t nYSize,
     {
         TIFFSetField(hTIFF, TIFFTAG_YCBCRSUBSAMPLING, nHorSubsampling,
                      nVerSubsampling);
-        /* TODO: also write YCbCrPositioning and YCbCrCoefficients tag identical
-         * to source IFD */
+        TIFFSetField(hTIFF, TIFFTAG_YCBCRPOSITIONING, nYCbCrPositioning);
+        if (pfYCbCrCoeffs)
+            TIFFSetField(hTIFF, TIFFTAG_YCBCRCOEFFICIENTS, pfYCbCrCoeffs);
     }
     /* TODO: add command-line parameter for selecting jpeg compression quality
      * that gets ignored when compression isn't jpeg */


### PR DESCRIPTION
## Summary
- copy YCbCrPositioning and YCbCrCoefficients from the base image
- set these tags on the overview TIFF before writing

## Testing
- `pre-commit run --files contrib/addtiffo/tif_overview.c`
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: Can't create test TIFF files)*

------
https://chatgpt.com/codex/tasks/task_e_684f0cc22b908321aff0da1e719a5bab