### PR TITLE
Add JPEG quality option to addtiffo

### DIFF
--- a/contrib/addtiffo/README
+++ b/contrib/addtiffo/README
@@ -19,11 +19,15 @@ http://home.gdal.org/~warmerda/
 Usage
 -----
 
-Usage: addtiffo [-r {nearest,average,mode}] [-subifd]
+Usage: addtiffo [-r {nearest,average,mode}] [-j quality] [-subifd]
                 tiff_filename [resolution_reductions]
 
 Example:
  % addtiffo abc.tif 2 4 8 16
+
+The ``-j`` option sets the JPEG compression quality for the generated
+overviews (default is 75).  It is ignored if the source image is not
+compressed with JPEG.
 
 The numeric arguments are the list of reduction factors to 
 generate.  In this example a 1/2, 1/4 1/8 and 1/16 

--- a/contrib/addtiffo/addtiffo.c
+++ b/contrib/addtiffo/addtiffo.c
@@ -67,7 +67,7 @@
 #include <string.h>
 
 void TIFFBuildOverviews(TIFF *, int, int *, int, OVRResampleMethod,
-                        int (*)(double, void *), void *);
+                        int (*)(double, void *), void *, int);
 
 /************************************************************************/
 /*                                main()                                */
@@ -81,13 +81,14 @@ int main(int argc, char **argv)
     int bUseSubIFD = 0;
     TIFF *hTIFF;
     OVRResampleMethod eResampling = OVR_RESAMPLE_NEAREST;
+    int nJpegQuality = 75;
 
     /* -------------------------------------------------------------------- */
     /*      Usage:                                                          */
     /* -------------------------------------------------------------------- */
     if (argc < 2)
     {
-        printf("Usage: addtiffo [-r {nearest,average,mode}]\n"
+        printf("Usage: addtiffo [-r {nearest,average,mode}] [-j quality]\n"
                "                tiff_filename [resolution_reductions]\n"
                "\n"
                "Example:\n"
@@ -119,6 +120,12 @@ int main(int argc, char **argv)
                 free(anOverviews);
                 return (1);
             }
+        }
+        else if (strcmp(argv[1], "-j") == 0 && argc > 2)
+        {
+            nJpegQuality = atoi(argv[2]);
+            argv += 2;
+            argc -= 2;
         }
         else
         {
@@ -192,7 +199,7 @@ int main(int argc, char **argv)
     /* -------------------------------------------------------------------- */
     if (nOverviewCount > 0)
         TIFFBuildOverviews(hTIFF, nOverviewCount, anOverviews, bUseSubIFD,
-                           eResampling, NULL, NULL);
+                           eResampling, NULL, NULL, nJpegQuality);
 
     TIFFClose(hTIFF);
 

--- a/contrib/addtiffo/tif_overview.c
+++ b/contrib/addtiffo/tif_overview.c
@@ -71,7 +71,7 @@
 #define TIFF_DIR_MAX 65534
 
 void TIFFBuildOverviews(TIFF *, int, int *, int, OVRResampleMethod,
-                        int (*)(double, void *), void *);
+                        int (*)(double, void *), void *, int);
 
 /************************************************************************/
 /*                         TIFF_WriteOverview()                         */
@@ -89,7 +89,7 @@ uint32_t TIFF_WriteOverview(TIFF *hTIFF, uint32_t nXSize, uint32_t nYSize,
                             int nSampleFormat, unsigned short *panRed,
                             unsigned short *panGreen, unsigned short *panBlue,
                             int bUseSubIFDs, int nHorSubsampling,
-                            int nVerSubsampling)
+                            int nVerSubsampling, int nJpegQuality)
 
 {
     toff_t nBaseDirOffset;
@@ -145,8 +145,8 @@ uint32_t TIFF_WriteOverview(TIFF *hTIFF, uint32_t nXSize, uint32_t nYSize,
         if (pfYCbCrCoeffs)
             TIFFSetField(hTIFF, TIFFTAG_YCBCRCOEFFICIENTS, pfYCbCrCoeffs);
     }
-    /* TODO: add command-line parameter for selecting jpeg compression quality
-     * that gets ignored when compression isn't jpeg */
+    if (nCompressFlag == COMPRESSION_JPEG && nJpegQuality > 0)
+        TIFFSetField(hTIFF, TIFFTAG_JPEGQUALITY, nJpegQuality);
 
     /* -------------------------------------------------------------------- */
     /*	Write color table if one is present.				*/
@@ -734,7 +734,8 @@ void TIFF_ProcessFullResBlock(TIFF *hTIFF, int nPlanarConfig, int bSubsampled,
 
 void TIFFBuildOverviews(TIFF *hTIFF, int nOverviews, int *panOvList,
                         int bUseSubIFDs, OVRResampleMethod eResampleMethod,
-                        int (*pfnProgress)(double, void *), void *pProgressData)
+                        int (*pfnProgress)(double, void *), void *pProgressData,
+                        int nJpegQuality)
 
 {
     TIFFOvrCache **papoRawBIs;
@@ -885,7 +886,7 @@ void TIFFBuildOverviews(TIFF *hTIFF, int nOverviews, int *panOvList,
             hTIFF, nOXSize, nOYSize, nBitsPerPixel, nPlanarConfig, nSamples,
             nOBlockXSize, nOBlockYSize, bTiled, nCompressFlag, nPhotometric,
             nSampleFormat, panRedMap, panGreenMap, panBlueMap, bUseSubIFDs,
-            nHorSubsampling, nVerSubsampling);
+            nHorSubsampling, nVerSubsampling, nJpegQuality);
 
         papoRawBIs[i] = TIFFCreateOvrCache(hTIFF, nDirOffset);
     }

--- a/contrib/addtiffo/tif_ovrcache.h
+++ b/contrib/addtiffo/tif_ovrcache.h
@@ -83,7 +83,7 @@ extern "C"
     } OVRResampleMethod;
 
     void TIFFBuildOverviews(TIFF *, int, int *, int, OVRResampleMethod,
-                            int (*)(double, void *), void *);
+                            int (*)(double, void *), void *, int);
 
     void TIFF_ProcessFullResBlock(TIFF *, int, int, int, int, int, int *, int,
                                   int, TIFFOvrCache **, uint32_t, uint32_t,
@@ -93,7 +93,7 @@ extern "C"
     uint32_t TIFF_WriteOverview(TIFF *, uint32_t, uint32_t, int, int, int, int,
                                 int, int, int, int, int, unsigned short *,
                                 unsigned short *, unsigned short *, int, int,
-                                int);
+                                int, int);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary
- allow specifying JPEG quality when building overviews
- wire JPEG quality through TIFF_WriteOverview
- document new `-j` option for `addtiffo`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest` *(fails: 156 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f0de4eba08321ae88e47da5683da6