### PR TITLE
Fix allocation check in TIFF_DownSample

### DIFF
--- a/contrib/addtiffo/tif_overview.c
+++ b/contrib/addtiffo/tif_overview.c
@@ -314,9 +314,11 @@ static void TIFF_DownSample(unsigned char *pabySrcTile, uint32_t nBlockXSize,
     }
     if (padfSamples_size == 0)
     {
-        /* TODO: This is an error condition */
+        TIFFError("TIFF_DownSample",
+                  "Invalid padfSamples_size -- integer overflow detected");
         return;
     }
+
     padfSamples = (double *)malloc(padfSamples_size);
 
     /* ==================================================================== */


### PR DESCRIPTION
## Summary
- prevent allocation with zero `padfSamples_size`
- emit a `TIFFError` message before returning

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(fails: tiffcrop-extract, addtiffo-default-small, addtiffo-default-large, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f0fce693883218016bf977f898d9f