### PR TITLE
Fix addtiffo error messaging

### DIFF
--- a/contrib/addtiffo/addtiffo.c
+++ b/contrib/addtiffo/addtiffo.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
                 eResampling = OVR_RESAMPLE_MODE;
             else
             {
-                fprintf(stderr, "Unknown resampling method: %s\n", *argv);
+                TIFFError("addtiffo", "Unknown resampling method: %s", *argv);
                 free(anOverviews);
                 return (1);
             }
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
         }
         else
         {
-            fprintf(stderr, "Incorrect parameters\n");
+            TIFFError("addtiffo", "Incorrect parameters");
             return (1);
         }
     }
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
     hTIFF = TIFFOpen(argv[1], "r+");
     if (hTIFF == NULL)
     {
-        fprintf(stderr, "TIFFOpen(%s) failed.\n", argv[1]);
+        TIFFError("addtiffo", "TIFFOpen(%s) failed.", argv[1]);
         return (1);
     }
 
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
         anOverviews = (int *)calloc(nOverviewCount, sizeof(int));
         if (anOverviews == NULL)
         {
-            fprintf(stderr, "Out of memory.\n");
+            TIFFError("addtiffo", "Out of memory.");
             TIFFClose(hTIFF);
             return (1);
         }
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
             anOverviews[i] = atoi(argv[i + 2]);
             if (anOverviews[i] <= 0 || anOverviews[i] > 1024)
             {
-                fprintf(stderr, "Incorrect parameters\n");
+                TIFFError("addtiffo", "Incorrect parameters");
                 free(anOverviews);
                 TIFFClose(hTIFF);
                 return (1);
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
                 (int *)realloc(anOverviews, sizeof(int) * (nOverviewCount + 1));
             if (tmp == NULL)
             {
-                fprintf(stderr, "Out of memory.\n");
+                TIFFError("addtiffo", "Out of memory.");
                 free(anOverviews);
                 TIFFClose(hTIFF);
                 return (1);

--- a/contrib/addtiffo/tif_overview.c
+++ b/contrib/addtiffo/tif_overview.c
@@ -779,8 +779,6 @@ void TIFFBuildOverviews(TIFF *hTIFF, int nOverviews, int *panOvList,
             nPlanarConfig != PLANARCONFIG_CONTIG ||
             nSampleFormat != SAMPLEFORMAT_UINT)
         {
-            /* TODO: use of TIFFError is inconsistent with use of fprintf in
-             * addtiffo.c, sort out */
             TIFFErrorExt(
                 TIFFClientdata(hTIFF), "TIFFBuildOverviews",
                 "File `%s' has an unsupported subsampling configuration.\n",
@@ -801,8 +799,6 @@ void TIFFBuildOverviews(TIFF *hTIFF, int nOverviews, int *panOvList,
     {
         if (nBitsPerSample < 8)
         {
-            /* TODO: use of TIFFError is inconsistent with use of fprintf in
-             * addtiffo.c, sort out */
             TIFFErrorExt(
                 TIFFClientdata(hTIFF), "TIFFBuildOverviews",
                 "File `%s' has samples of %d bits per sample.  Sample\n"

--- a/contrib/addtiffo/tif_ovrcache.c
+++ b/contrib/addtiffo/tif_ovrcache.c
@@ -259,7 +259,9 @@ static void TIFFWriteOvrRow(TIFFOvrCache *psCache)
                     if (TIFFWriteEncodedTile(psCache->hTIFF, nTileID, pabyData,
                                              TIFFTileSize(psCache->hTIFF)) < 0)
                     {
-                        fprintf(stderr, "TIFFWriteEncodedTile() failed\n");
+                        TIFFErrorExt(TIFFClientdata(psCache->hTIFF),
+                                     "TIFFWriteOvrRow()",
+                                     "TIFFWriteEncodedTile() failed");
                     }
                 }
                 else
@@ -271,12 +273,14 @@ static void TIFFWriteOvrRow(TIFFOvrCache *psCache)
                     if ((iTileY + 1) * psCache->nBlockYSize > psCache->nYSize)
                         RowsInStrip =
                             psCache->nYSize - iTileY * psCache->nBlockYSize;
-                    if (TIFFWriteEncodedStrip(
-                            psCache->hTIFF, nTileID, pabyData,
-                            TIFFVStripSize(psCache->hTIFF, RowsInStrip)) < 0)
-                    {
-                        fprintf(stderr, "TIFFWriteEncodedStrip() failed\n");
-                    }
+                      if (TIFFWriteEncodedStrip(
+                              psCache->hTIFF, nTileID, pabyData,
+                              TIFFVStripSize(psCache->hTIFF, RowsInStrip)) < 0)
+                      {
+                          TIFFErrorExt(TIFFClientdata(psCache->hTIFF),
+                                       "TIFFWriteOvrRow()",
+                                       "TIFFWriteEncodedStrip() failed");
+                      }
                 }
             }
         }
@@ -292,7 +296,9 @@ static void TIFFWriteOvrRow(TIFFOvrCache *psCache)
                 if (TIFFWriteEncodedTile(psCache->hTIFF, nTileID, pabyData,
                                          TIFFTileSize(psCache->hTIFF)) < 0)
                 {
-                    fprintf(stderr, "TIFFWriteEncodedTile() failed\n");
+                    TIFFErrorExt(TIFFClientdata(psCache->hTIFF),
+                                 "TIFFWriteOvrRow()",
+                                 "TIFFWriteEncodedTile() failed");
                 }
             }
             else
@@ -307,7 +313,9 @@ static void TIFFWriteOvrRow(TIFFOvrCache *psCache)
                         psCache->hTIFF, nTileID, pabyData,
                         TIFFVStripSize(psCache->hTIFF, RowsInStrip)) < 0)
                 {
-                    fprintf(stderr, "TIFFWriteEncodedStrip() failed\n");
+                    TIFFErrorExt(TIFFClientdata(psCache->hTIFF),
+                                 "TIFFWriteOvrRow()",
+                                 "TIFFWriteEncodedStrip() failed");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- switch remaining fprintf error messages to TIFFError
- remove outdated TODOs mentioning mixed error handling

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-32bpp-None, addtiffo-default-small, and others)*

------
https://chatgpt.com/codex/tasks/task_e_684f14bf2d10832193f95729b3a330ff