### PR TITLE
Use TIFFGetFieldDefaulted for YCbCr subsampling

### DIFF
--- a/contrib/addtiffo/tif_overview.c
+++ b/contrib/addtiffo/tif_overview.c
@@ -790,10 +790,9 @@ void TIFFBuildOverviews(TIFF *hTIFF, int nOverviews, int *panOvList,
             return;
         }
         bSubsampled = 1;
-        TIFFGetField(hTIFF, TIFFTAG_YCBCRSUBSAMPLING, &nHorSubsampling,
-                     &nVerSubsampling);
-        /* TODO: find out if maybe TIFFGetFieldDefaulted is better choice for
-         * YCbCrSubsampling tag */
+        TIFFGetFieldDefaulted(hTIFF, TIFFTAG_YCBCRSUBSAMPLING, &nHorSubsampling,
+                              &nVerSubsampling);
+        /* Use defaults if the YCbCrSubsampling tag is missing */
     }
     else
     {


### PR DESCRIPTION
## Summary
- use `TIFFGetFieldDefaulted` when reading YCbCr subsampling

## Testing
- `pre-commit run --files contrib/addtiffo/tif_overview.c`
- `cmake --build build -j1` *(fails: `_mm_extract_epi8` target option mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684f184a21108321a5b0689712ad6dc5