### PR TITLE
Fix height check when parsing SOF

### DIFF
--- a/libtiff/tif_ojpeg.c
+++ b/libtiff/tif_ojpeg.c
@@ -1862,6 +1862,13 @@ static int OJPEGReadHeaderInfoSecStreamSof(TIFF *tif, uint8_t marker_id)
                           "JPEG compressed data indicates unexpected height");
             return (0);
         }
+        if ((uint32_t)p > sp->strile_length_total)
+        {
+            TIFFErrorExtR(tif, module,
+                          "JPEG compressed data image height exceeds expected "
+                          "image height");
+            return (0);
+        }
         sp->sof_y = p;
         /* X: Number of samples per line */
         if (OJPEGReadWord(sp, &p) == 0)


### PR DESCRIPTION
## Summary
- validate that the SOF height declared in JPEG data does not exceed the expected strile height

## Testing
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(fails: Error writing TIFF header)*


------
https://chatgpt.com/codex/tasks/task_e_684fa304b084832184b47eeaf4b5e7eb