### PR TITLE
Handle DotRange tag comments

### DIFF
--- a/doc/functions/TIFFGetField.rst
+++ b/doc/functions/TIFFGetField.rst
@@ -118,7 +118,7 @@ information on the meaning of each tag and their possible values.
     * - :c:macro:`TIFFTAG_DOTRANGE`
       - 2
       - :c:expr:`uint16_t*`
-      -
+      - § values returned separately
 
     * - :c:macro:`TIFFTAG_EXTRASAMPLES`
       - 2
@@ -444,6 +444,11 @@ information on the meaning of each tag and their possible values.
   "The ICC Profile Format Specification",
   Annex B.3 "Embedding ICC Profiles in TIFF Files" (available at
   http://www.color.org) for an explanation.
+
+§:
+  ``TIFFTAG_DOTRANGE`` is stored internally as a pair of ``uint16_t`` values
+  that are returned as two separate arguments when calling
+  :c:func:`TIFFGetField` or :c:func:`TIFFSetField`.
 
 Autoregistered tags
 -------------------

--- a/doc/functions/TIFFSetField.rst
+++ b/doc/functions/TIFFSetField.rst
@@ -117,7 +117,7 @@ Consult the TIFF specification for information on the meaning of each tag.
     * - :c:macro:`TIFFTAG_DOTRANGE`
       - 2
       - :c:expr:`uint16_t`
-      -
+      - § values passed separately
     * - :c:macro:`TIFFTAG_EXTRASAMPLES`
       - 2
       - :c:expr:`uint16_t`, :c:expr:`uint16_t*`
@@ -362,6 +362,11 @@ Consult the TIFF specification for information on the meaning of each tag.
 
   If ``SamplesPerPixel`` is one, then a single array is passed;
   otherwise three arrays should be passed.
+
+§:
+  ``TIFFTAG_DOTRANGE`` is handled as two ``uint16_t`` values that are
+  passed as separate arguments when calling :c:func:`TIFFSetField` and
+  :c:func:`TIFFGetField`.
 
 \*:
   The contents of this field are quite complex.  See

--- a/libtiff/tif_dir.c
+++ b/libtiff/tif_dir.c
@@ -201,7 +201,8 @@ static bool equalCustomValue(const void *elt1, const void *elt2)
 
 static int TIFFBuildCustomValueMap(TIFFDirectory *td)
 {
-    TIFFHashSet *newMap = TIFFHashSetNew(hashCustomValue, equalCustomValue, NULL);
+    TIFFHashSet *newMap =
+        TIFFHashSetNew(hashCustomValue, equalCustomValue, NULL);
     if (!newMap)
         return 0;
     for (int i = 0; i < td->td_customValueCount; i++)
@@ -874,10 +875,10 @@ static int _TIFFVSetField(TIFF *tif, uint32_t tag, va_list ap)
                 if (fip->field_tag == TIFFTAG_DOTRANGE &&
                     strcmp(fip->field_name, "DotRange") == 0)
                 {
-                    /* TODO: This is an evil exception and should not have been
-                       handled this way ... likely best if we move it into
-                       the directory structure with an explicit field in
-                       libtiff 4.1 and assign it a FIELD_ value */
+                    /* DotRange is stored as a pair of uint16 values and uses
+                     * the TIFF_SETGET_UINT16_PAIR accessor.  The values are
+                     * passed separately to TIFFSetField(), so we must pack
+                     * them into a temporary array here. */
                     uint16_t v2[2];
                     v2[0] = (uint16_t)va_arg(ap, int);
                     v2[1] = (uint16_t)va_arg(ap, int);
@@ -1497,10 +1498,10 @@ static int _TIFFVGetField(TIFF *tif, uint32_t tag, va_list ap)
                 else if (fip->field_tag == TIFFTAG_DOTRANGE &&
                          strcmp(fip->field_name, "DotRange") == 0)
                 {
-                    /* TODO: This is an evil exception and should not have been
-                       handled this way ... likely best if we move it into
-                       the directory structure with an explicit field in
-                       libtiff 4.1 and assign it a FIELD_ value */
+                    /* DotRange returns two uint16 values using
+                     * TIFF_SETGET_UINT16_PAIR.  Retrieve each element from the
+                     * stored array and return them in the order expected by
+                     * TIFFGetField(). */
                     *va_arg(ap, uint16_t *) = ((uint16_t *)tv->value)[0];
                     *va_arg(ap, uint16_t *) = ((uint16_t *)tv->value)[1];
                     ret_val = 1;

--- a/libtiff/tif_print.c
+++ b/libtiff/tif_print.c
@@ -659,10 +659,9 @@ void TIFFPrintDirectory(TIFF *tif, FILE *fd, long flags)
                 if (fip->field_tag == TIFFTAG_DOTRANGE &&
                     strcmp(fip->field_name, "DotRange") == 0)
                 {
-                    /* TODO: This is an evil exception and should not have been
-                       handled this way ... likely best if we move it into
-                       the directory structure with an explicit field in
-                       libtiff 4.1 and assign it a FIELD_ value */
+                    /* DotRange uses TIFF_SETGET_UINT16_PAIR and stores two
+                     * uint16 values.  Fetch them separately into the temporary
+                     * array so TIFFPrintDirectory() can display them. */
                     raw_data = dotrange;
                     TIFFGetField(tif, tag, dotrange + 0, dotrange + 1);
                 }


### PR DESCRIPTION
## Summary
- clarify DotRange special case comments in tif_dir.c and tif_print.c
- document DotRange handling in TIFFSetField and TIFFGetField manuals

## Testing
- `pre-commit run --files libtiff/tif_dir.c libtiff/tif_print.c doc/functions/TIFFSetField.rst doc/functions/TIFFGetField.rst`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa5e239c48321a70c607ed602eec5