### PR TITLE
Add partial buffer seek test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -230,6 +230,12 @@ set_target_properties(test_append_to_strip PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(test_append_to_strip PRIVATE tiff tiff_port)
 list(APPEND simple_tests test_append_to_strip)
 
+add_executable(test_seek_partial ../placeholder.h)
+target_sources(test_seek_partial PRIVATE test_seek_partial.c)
+set_target_properties(test_seek_partial PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(test_seek_partial PRIVATE tiff tiff_port)
+list(APPEND simple_tests test_seek_partial)
+
 add_executable(test_ifd_loop_detection ../placeholder.h)
 target_sources(test_ifd_loop_detection PRIVATE test_ifd_loop_detection.c)
 set_target_properties(test_ifd_loop_detection PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -104,7 +104,7 @@ if TIFF_TESTS
 check_PROGRAMS = \
        ascii_tag long_tag short_tag strip_rw rewrite custom_dir custom_dir_EXIF_231 \
        defer_strile_loading defer_strile_writing test_directory test_IFD_enlargement test_open_options \
-       test_append_to_strip test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test memmove_simd_test reverse_bits_neon_test bayer_pack_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS) \
+       test_append_to_strip test_seek_partial test_ifd_loop_detection swab_neon_test assemble_strip_neon_test gray_flip_neon_test memmove_simd_test reverse_bits_neon_test bayer_pack_test swab_benchmark predictor_threadpool_benchmark pack_uring_benchmark testtypes test_signed_tags uring_rw $(JPEG_DEPENDENT_CHECK_PROG) $(STATIC_CHECK_PROGS) \
        bayer_simd_benchmark \
        rgb_pack_neon_test \
        packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize ycbcr_neon_test
@@ -315,6 +315,8 @@ test_open_options_SOURCES = test_open_options.c
 test_open_options_LDADD = $(LIBTIFF)
 test_append_to_strip_SOURCES = test_append_to_strip.c
 test_append_to_strip_LDADD = $(LIBTIFF)
+test_seek_partial_SOURCES = test_seek_partial.c
+test_seek_partial_LDADD = $(LIBTIFF)
 test_ifd_loop_detection_CFLAGS = -DSOURCE_DIR=\"@srcdir@\"
 test_ifd_loop_detection_SOURCES = test_ifd_loop_detection.c
 test_ifd_loop_detection_LDADD = $(LIBTIFF)

--- a/test/test_seek_partial.c
+++ b/test/test_seek_partial.c
@@ -1,0 +1,84 @@
+#include "tif_config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include "tiffio.h"
+
+int main(void)
+{
+#ifndef CHUNKY_STRIP_READ_SUPPORT
+    printf("CHUNKY_STRIP_READ_SUPPORT not enabled. Skipping test.\n");
+    return 0;
+#else
+    const char *srcdir = getenv("srcdir");
+    if (!srcdir)
+        srcdir = ".";
+    char filename[1024];
+    snprintf(filename, sizeof(filename), "%s/images/minisblack-1c-8b.tiff", srcdir);
+
+    TIFF *tif = TIFFOpen(filename, "r");
+    if (!tif)
+    {
+        fprintf(stderr, "Cannot open %s\n", filename);
+        return 1;
+    }
+
+    uint32_t width = 0, height = 0;
+    TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &width);
+    TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &height);
+    tmsize_t scanline = TIFFScanlineSize(tif);
+
+    uint8_t *baseline = (uint8_t *)_TIFFmalloc(scanline * height);
+    uint8_t *buf = (uint8_t *)_TIFFmalloc(scanline);
+    if (!baseline || !buf)
+    {
+        fprintf(stderr, "Memory allocation failed\n");
+        return 1;
+    }
+
+    for (uint32_t row = 0; row < height; row++)
+    {
+        if (TIFFReadScanline(tif, baseline + row * scanline, row, 0) < 0)
+        {
+            fprintf(stderr, "TIFFReadScanline failed at row %u\n", row);
+            return 1;
+        }
+    }
+    TIFFClose(tif);
+
+    tif = TIFFOpen(filename, "r");
+    if (!tif)
+    {
+        fprintf(stderr, "Cannot reopen %s\n", filename);
+        return 1;
+    }
+
+    uint32_t rows[] = {0, 10, 5, 20, 19, 2, height - 1, 1};
+    int n = sizeof(rows) / sizeof(rows[0]);
+    for (int i = 0; i < n; i++)
+    {
+        uint32_t r = rows[i];
+        if (r >= height)
+            r = height - 1;
+        if (TIFFReadScanline(tif, buf, r, 0) < 0)
+        {
+            fprintf(stderr, "Seek/Read failed at row %u\n", r);
+            return 1;
+        }
+        if (memcmp(buf, baseline + r * scanline, scanline) != 0)
+        {
+            fprintf(stderr, "Data mismatch at row %u\n", r);
+            return 1;
+        }
+    }
+
+    TIFFClose(tif);
+    _TIFFfree(buf);
+    _TIFFfree(baseline);
+    fprintf(stderr, "test_seek_partial completed OK\n");
+    return 0;
+#endif
+}


### PR DESCRIPTION
## Summary
- add a new `test_seek_partial` program to exercise `TIFFSeek`
- build and run the test via autotools and cmake

## Testing
- `cmake .. -Dchunky-strip-read=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: tiffcrop-extract-32bpp-None, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684fa74c99588321b0a5b1a6ecc9d840