### PR TITLE
Add async DNG writing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ free(s);
 free(tmp);
 ```
 
+See [doc/async_dng.rst](doc/async_dng.rst) for a detailed overview of
+asynchronous DNG creation and tuning options.
+
 Packing helpers for raw Bayer buffers:
 ```c
 TIFFPackRaw12(src16, packed, count, 0);

--- a/doc/async_dng.rst
+++ b/doc/async_dng.rst
@@ -1,0 +1,29 @@
+Asynchronous DNG Writing
+========================
+
+The thread pool allows libtiff to assemble and compress image strips in
+parallel. Build with ``-Dthreadpool=ON`` (CMake) or
+``--enable-multithreading`` (Autotools) to enable it. The pool size
+defaults to the number of processors but can be overridden with the
+``TIFF_THREAD_COUNT`` environment variable or by calling
+``TIFFSetThreadCount()``.
+
+When configured with ``-Dio-uring=ON`` or ``--enable-io-uring`` libtiff
+uses Linux ``io_uring`` for asynchronous I/O. The submission queue depth
+starts at eight. Tune it through the ``TIFF_URING_DEPTH`` environment
+variable, ``TIFFOpenOptionsSetURingQueueDepth()`` before opening a file,
+or at runtime with ``TIFFSetURingQueueDepth()``.
+
+An application typically assembles each strip and queues the write while
+the next strip is prepared::
+
+    _tiffUringSetAsync(tif, 1);
+    for (...) {
+        TIFFAssembleStripNEON(tif, src, w, rows, 1, 1, &sz, tmp, buf);
+        _tiffUringWriteProc((thandle_t)TIFFFileno(tif), buf, (tmsize_t)sz);
+    }
+    _TIFFThreadPoolWait(pool);
+    _tiffUringWait(tif);
+
+Adjust ``TIFF_THREAD_COUNT`` and ``TIFFSetURingQueueDepth()`` for the
+best throughput on your system.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,6 +61,7 @@ The following sections are included in this documentation:
     internals
     bayer12neon
     zipneon
+    async_dng
     addingtags
     tools
     contrib


### PR DESCRIPTION
## Summary
- document asynchronous DNG creation
- link async_dng doc from index and README

## Testing
- `pre-commit run --files doc/async_dng.rst doc/index.rst README.md`
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: test suite execution)*

------
https://chatgpt.com/codex/tasks/task_e_684fc5ef9cf08321bb5088b5e818522c