### PR TITLE
Add NEON 16-bit Bayer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ $ ./configure --host=x86_64-linux-gnu CFLAGS="-msse4.1" --enable-shared
 
 ### NEON 12‑bit Bayer Packing
 The functions `TIFFPackRaw12()` and `TIFFUnpackRaw12()` leverage NEON to process 16 pixels per iteration and fall back to scalar code when NEON is unavailable.  On an RK3588 (ARMv8) system the NEON path provides about **6×** packing and **5×** unpacking speedups【F:doc/bayer12neon.rst†L1-L12】.
+The companion routines `TIFFPackRaw16()` and `TIFFUnpackRaw16()` operate on
+16-bit samples with a similar automatic fallback【F:doc/bayer16neon.rst†L1-L8】.
 
 ### NEON Byte Swapping
 Byte-swapping routines accelerate endian conversion with vector instructions:

--- a/doc/bayer16neon.rst
+++ b/doc/bayer16neon.rst
@@ -1,0 +1,9 @@
+Bayer 16-bit NEON Optimizations
+===============================
+
+libtiff provides helper routines for packing and unpacking 16-bit Bayer
+samples to and from byte-aligned buffers. When built on ARM processors
+with NEON support, these routines leverage vector instructions to process
+eight pixels per iteration internally. The code automatically falls back
+to a portable C implementation when NEON is unavailable.
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,6 +60,7 @@ The following sections are included in this documentation:
     functions
     internals
     bayer12neon
+    bayer16neon
     zipneon
     async_dng
     addingtags


### PR DESCRIPTION
## Summary
- document NEON routines for 16-bit Bayer packing/unpacking
- link new docs in the index
- mention these new routines in README

## Testing
- `cmake -S . -B builddir -DCMAKE_BUILD_TYPE=Release -DHAVE_SSE41=0`
- `cmake --build builddir -j$(nproc)`
- `ctest --output-on-failure` *(fails: several tests tiffcrop-extractz14-*)*

------
https://chatgpt.com/codex/tasks/task_e_684fc8a42cc0832194c67dc4c5aff242