### PR TITLE
Fix overlapping copies in iptcutil

### DIFF
--- a/contrib/iptcutil/iptcutil.c
+++ b/contrib/iptcutil/iptcutil.c
@@ -158,7 +158,7 @@ int convertHTMLcodes(char *s, int len)
                     break;
             }
             if (o < 5)
-                strcpy(s + 1, s + 1 + o);
+                memmove(s + 1, s + 1 + o, strlen(s + 1 + o) + 1);
             *s = val;
             return o;
         }
@@ -172,7 +172,8 @@ int convertHTMLcodes(char *s, int len)
             if (html_codes[i].len <= len)
                 if (STRNICMP(s, html_codes[i].code, html_codes[i].len) == 0)
                 {
-                    strcpy(s + 1, s + html_codes[i].len);
+                    memmove(s + 1, s + html_codes[i].len,
+                            strlen(s + html_codes[i].len) + 1);
                     *s = html_codes[i].val;
                     return html_codes[i].len - 1;
                 }


### PR DESCRIPTION
## Summary
- replace overlapping `strcpy` calls with `memmove`

## Testing
- `pre-commit run --files contrib/iptcutil/iptcutil.c`
- `ctest --output-on-failure -j1` *(fails: Returned failed status No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684fced50a4c832183e3dc2017da61d1