### PR TITLE
Fix realloc usage patterns

### DIFF
--- a/contrib/iptcutil/iptcutil.c
+++ b/contrib/iptcutil/iptcutil.c
@@ -332,9 +332,10 @@ char *super_fgets(char *b, int *blen, FILE *file)
 
             tlen = (int)(q - b);
             len <<= 1;
-            b = (char *)realloc((char *)b, (len + 2));
-            if ((char *)b == (char *)NULL)
+            char *tmp = (char *)realloc((char *)b, (len + 2));
+            if (tmp == NULL)
                 break;
+            b = tmp;
             q = b + tlen;
         }
         *q = (unsigned char)c;

--- a/tools/fax2ps.c
+++ b/tools/fax2ps.c
@@ -364,14 +364,24 @@ int main(int argc, char **argv)
             case 'p': /* print specific page */
                 pageNumber = (uint16_t)atoi(optarg);
                 if (pages)
-                    pages = (uint16_t *)realloc(pages, (npages + 1) *
-                                                           sizeof(uint16_t));
-                else
-                    pages = (uint16_t *)malloc(sizeof(uint16_t));
-                if (pages == NULL)
                 {
-                    fprintf(stderr, "Out of memory\n");
-                    exit(EXIT_FAILURE);
+                    uint16_t *new_pages =
+                        (uint16_t *)realloc(pages, (npages + 1) * sizeof(uint16_t));
+                    if (new_pages == NULL)
+                    {
+                        fprintf(stderr, "Out of memory\n");
+                        exit(EXIT_FAILURE);
+                    }
+                    pages = new_pages;
+                }
+                else
+                {
+                    pages = (uint16_t *)malloc(sizeof(uint16_t));
+                    if (pages == NULL)
+                    {
+                        fprintf(stderr, "Out of memory\n");
+                        exit(EXIT_FAILURE);
+                    }
                 }
                 pages[npages++] = pageNumber;
                 break;

--- a/tools/thumbnail.c
+++ b/tools/thumbnail.c
@@ -353,10 +353,11 @@ static int cpStrips(TIFF *in, TIFF *out)
         {
             if (bytecounts[s] > (uint64_t)bufsize)
             {
-                buf =
-                    (unsigned char *)_TIFFrealloc(buf, (tmsize_t)bytecounts[s]);
-                if (!buf)
+                unsigned char *newbuf = (unsigned char *)_TIFFrealloc(
+                    buf, (tmsize_t)bytecounts[s]);
+                if (!newbuf)
                     goto bad;
+                buf = newbuf;
                 bufsize = (tmsize_t)bytecounts[s];
             }
             if (TIFFReadRawStrip(in, s, buf, (tmsize_t)bytecounts[s]) < 0 ||
@@ -390,10 +391,11 @@ static int cpTiles(TIFF *in, TIFF *out)
         {
             if (bytecounts[t] > (uint64_t)bufsize)
             {
-                buf =
-                    (unsigned char *)_TIFFrealloc(buf, (tmsize_t)bytecounts[t]);
-                if (!buf)
+                unsigned char *newbuf = (unsigned char *)_TIFFrealloc(
+                    buf, (tmsize_t)bytecounts[t]);
+                if (!newbuf)
                     goto bad;
+                buf = newbuf;
                 bufsize = (tmsize_t)bytecounts[t];
             }
             if (TIFFReadRawTile(in, t, buf, (tmsize_t)bytecounts[t]) < 0 ||

--- a/tools/tiffdump.c
+++ b/tools/tiffdump.c
@@ -256,8 +256,11 @@ static void dump(int fd, uint64_t diroff)
             }
             else
             {
-                visited_diroff =
+                uint64_t *new_visited =
                     (uint64_t *)realloc(visited_diroff, alloc_size);
+                if (!new_visited)
+                    Fatal("Out of memory");
+                visited_diroff = new_visited;
             }
         }
         if (!visited_diroff)


### PR DESCRIPTION
## Summary
- ensure `realloc` uses a temporary variable before assigning
- fix allocation checks in `iptcutil`, `fax2ps`, `thumbnail`, `tiffdump`

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: Can't create test TIFF file)*

------
https://chatgpt.com/codex/tasks/task_e_684fd041b7c8832198f92640dc73487a