### PR TITLE
Handle float swabbing in raw2tiff

### DIFF
--- a/tools/raw2tiff.c
+++ b/tools/raw2tiff.c
@@ -416,7 +416,9 @@ static void swapBytesInScanline(void *buf, uint32_t width, TIFFDataType dtype)
         case TIFF_SLONG:
             TIFFSwabArrayOfLong((uint32_t *)buf, (unsigned long)width);
             break;
-        /* case TIFF_FLOAT: */ /* FIXME */
+        case TIFF_FLOAT:
+            TIFFSwabArrayOfFloat((float *)buf, (unsigned long)width);
+            break;
         case TIFF_DOUBLE:
             TIFFSwabArrayOfDouble((double *)buf, (unsigned long)width);
             break;


### PR DESCRIPTION
## Summary
- support swapping `TIFF_FLOAT` data in raw2tiff

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684fdbeb709083218ef91ea706d8d935