### PR TITLE
Remove unused memset in PSDataBW

### DIFF
--- a/tools/tiff2ps.c
+++ b/tools/tiff2ps.c
@@ -2963,9 +2963,6 @@ void PSDataBW(FILE *fd, TIFF *tif, uint32_t w, uint32_t h)
         return;
     }
 
-    // FIXME
-    memset(tf_buf, 0, stripsize);
-
 #if defined(EXP_ASCII85ENCODER)
     if (ascii85_g)
     {


### PR DESCRIPTION
## Summary
- drop redundant memset in PSDataBW

## Testing
- `pre_commit run --files tools/tiff2ps.c`
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build .`
- `ctest` *(fails: addtiffo-subsampling-combinations and many others)*

------
https://chatgpt.com/codex/tasks/task_e_684fe0eaf5588321ae56b1ca74865577