### PR TITLE
Add vectorization audit tooling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ image: registry.gitlab.com/libtiff/libtiff-ci-ubuntu24.04:latest
 stages:
   - build
   - static-analysis
+  - vectorization
   - pages
 
 
@@ -54,6 +55,16 @@ coverity:
   only:
     refs:
       - master
+
+vectorization-audit:
+  stage: vectorization
+  image: registry.gitlab.com/libtiff/libtiff-ci-ubuntu24.04:latest
+  script:
+    - python3 scripts/vectorization_audit.py
+  artifacts:
+    paths:
+      - vector_build/build.log
+      - vector_build/cmake.log
 
 pages:
   stage: pages

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -66,6 +66,7 @@ The following sections are included in this documentation:
     addingtags
     tools
     contrib
+    vectorization_policy
     rfcs/index
     project/index
     releases/index

--- a/doc/vectorization_policy.rst
+++ b/doc/vectorization_policy.rst
@@ -1,0 +1,19 @@
+Vectorization Policy
+====================
+
+LibTIFF aims to keep performance‑critical loops vectorized on all supported
+architectures. Continuous integration runs ``scripts/vectorization_audit.py``
+which builds the library with ``clang`` and reports any loops missed by the
+vectorizer.
+
+Policy
+------
+
+* CI fails when ``vectorization_audit.py`` reports missed vectorization in
+  ``libtiff`` or ``tools`` sources.
+* Loops that cannot be vectorized must be annotated with
+  ``#pragma clang loop vectorize(disable)`` and a brief justification.
+* Refactor hot loops by hoisting invariants, simplifying bounds, and keeping
+  memory contiguous. The audit script uses ``-Rpass`` flags so developers can
+  spot missed opportunities locally.
+

--- a/scripts/vectorization_audit.py
+++ b/scripts/vectorization_audit.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+BUILD_DIR = Path('vector_build')
+
+CMAKE_FLAGS = [
+    '-DCMAKE_C_COMPILER=clang',
+    '-DCMAKE_C_FLAGS=-O2 -Rpass=loop-vectorize -Rpass-missed=loop-vectorize'
+]
+
+def run(cmd, cwd=None):
+    result = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+    return result.stdout + result.stderr, result.returncode
+
+def configure():
+    BUILD_DIR.mkdir(exist_ok=True)
+    out, code = run(['cmake', '..'] + CMAKE_FLAGS, cwd=BUILD_DIR)
+    Path(BUILD_DIR / 'cmake.log').write_text(out)
+    return code == 0
+
+def build():
+    out, _ = run(['make', '-k', f'-j{os.cpu_count()}'], cwd=BUILD_DIR)
+    Path(BUILD_DIR / 'build.log').write_text(out)
+    return out
+
+def parse(log):
+    pattern = re.compile(r'^(.*?):(\d+):\d+: remark: (.*?)(?: \[-Rpass.*\])')
+    missed = []
+    for line in log.splitlines():
+        m = pattern.match(line)
+        if not m:
+            continue
+        path, ln, msg = m.groups()
+        if 'not vectorized' in msg or 'not beneficial' in msg:
+            missed.append((path, int(ln), msg))
+    return missed
+
+def report(missed):
+    if not missed:
+        print('All loops vectorized')
+        return 0
+    print('Missed vectorization opportunities:')
+    for path, ln, msg in missed:
+        print(f"{path}:{ln}: {msg}")
+    print('\nSummary:')
+    counts = {}
+    for path, _, _ in missed:
+        counts[path] = counts.get(path, 0) + 1
+    for path, cnt in counts.items():
+        print(f"{path}: {cnt} misses")
+    return 1
+
+def main():
+    if not configure():
+        print('CMake configuration failed')
+        return 1
+    log = build()
+    missed = parse(log)
+    return report(missed)
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- script to run clang's loop vectorizer report and fail on missed loops
- CI job `vectorization-audit` to execute the script
- document vectorization policy

## Testing
- `pre-commit run --files scripts/vectorization_audit.py doc/vectorization_policy.rst doc/index.rst .gitlab-ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_684fecfde48083219b3e90dc15aac2a6