### PR TITLE
Add SSE4.1 RGB pack implementations

### DIFF
--- a/libtiff/tif_rgb.c
+++ b/libtiff/tif_rgb.c
@@ -4,6 +4,9 @@
 #if defined(HAVE_NEON) && defined(__ARM_NEON)
 #include <arm_neon.h>
 #endif
+#if defined(HAVE_SSE41)
+#include <smmintrin.h>
+
 
 static void pack_rgb24_scalar(const uint8_t *src, uint32_t *dst, size_t count)
 {
@@ -40,6 +43,219 @@ static void pack_rgba64_scalar(const uint16_t *src, uint32_t *dst, size_t count)
     }
 }
 
+static void pack_rgb24_sse41(const uint8_t *src, uint32_t *dst, size_t count)
+{
+    const __m128i alpha = _mm_set1_epi8((char)0xFF);
+    const __m128i rmask0 =
+        _mm_setr_epi8(0, 3, 6, 9, 12, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i rmask1 =
+        _mm_setr_epi8(2, 5, 8, 11, 14, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i rmask2 =
+        _mm_setr_epi8(1, 4, 7, 10, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i gmask0 =
+        _mm_setr_epi8(1, 4, 7, 10, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i gmask1 =
+        _mm_setr_epi8(0, 3, 6, 9, 12, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i gmask2 =
+        _mm_setr_epi8(2, 5, 8, 11, 14, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i bmask0 =
+        _mm_setr_epi8(2, 5, 8, 11, 14, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i bmask1 =
+        _mm_setr_epi8(1, 4, 7, 10, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i bmask2 =
+        _mm_setr_epi8(0, 3, 6, 9, 12, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    size_t i = 0;
+    for (; i + 16 <= count; i += 16)
+    {
+        __builtin_prefetch(src + i * 3 + 64);
+        __m128i t0 = _mm_loadu_si128((const __m128i *)(src + i * 3));
+        __m128i t1 = _mm_loadu_si128((const __m128i *)(src + i * 3 + 16));
+        __m128i t2 = _mm_loadu_si128((const __m128i *)(src + i * 3 + 32));
+        __m128i r = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, rmask0),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, rmask1), 6)),
+            _mm_slli_si128(_mm_shuffle_epi8(t2, rmask2), 11));
+        __m128i g = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, gmask0),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, gmask1), 5)),
+            _mm_slli_si128(_mm_shuffle_epi8(t2, gmask2), 11));
+        __m128i b = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, bmask0),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, bmask1), 5)),
+            _mm_slli_si128(_mm_shuffle_epi8(t2, bmask2), 10));
+
+        __m128i rg_lo = _mm_unpacklo_epi8(r, g);
+        __m128i rg_hi = _mm_unpackhi_epi8(r, g);
+        __m128i ba_lo = _mm_unpacklo_epi8(b, alpha);
+        __m128i ba_hi = _mm_unpackhi_epi8(b, alpha);
+        _mm_storeu_si128((__m128i *)(dst + i + 0),
+                         _mm_unpacklo_epi16(rg_lo, ba_lo));
+        _mm_storeu_si128((__m128i *)(dst + i + 4),
+                         _mm_unpackhi_epi16(rg_lo, ba_lo));
+        _mm_storeu_si128((__m128i *)(dst + i + 8),
+                         _mm_unpacklo_epi16(rg_hi, ba_hi));
+        _mm_storeu_si128((__m128i *)(dst + i + 12),
+                         _mm_unpackhi_epi16(rg_hi, ba_hi));
+    }
+    if (i < count)
+        pack_rgb24_scalar(src + i * 3, dst + i, count - i);
+}
+
+static void pack_rgba32_sse41(const uint8_t *src, uint32_t *dst, size_t count)
+{
+    const __m128i mask =
+        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    size_t i = 0;
+    for (; i + 16 <= count; i += 16)
+    {
+        __builtin_prefetch(src + i * 4 + 64);
+        __m128i v0 = _mm_loadu_si128((const __m128i *)(src + i * 4));
+        __m128i v1 = _mm_loadu_si128((const __m128i *)(src + i * 4 + 16));
+        __m128i v2 = _mm_loadu_si128((const __m128i *)(src + i * 4 + 32));
+        __m128i v3 = _mm_loadu_si128((const __m128i *)(src + i * 4 + 48));
+        v0 = _mm_shuffle_epi8(v0, mask);
+        v1 = _mm_shuffle_epi8(v1, mask);
+        v2 = _mm_shuffle_epi8(v2, mask);
+        v3 = _mm_shuffle_epi8(v3, mask);
+        _mm_storeu_si128((__m128i *)(dst + i + 0), v0);
+        _mm_storeu_si128((__m128i *)(dst + i + 4), v1);
+        _mm_storeu_si128((__m128i *)(dst + i + 8), v2);
+        _mm_storeu_si128((__m128i *)(dst + i + 12), v3);
+    }
+    if (i < count)
+        pack_rgba32_scalar(src + i * 4, dst + i, count - i);
+}
+
+static void pack_rgb48_sse41(const uint16_t *src, uint32_t *dst, size_t count)
+{
+    const __m128i alpha = _mm_set1_epi8((char)0xFF);
+    const __m128i rmask0 =
+        _mm_setr_epi8(0, 1, 6, 7, 12, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i rmask1 =
+        _mm_setr_epi8(2, 3, 8, 9, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i rmask2 =
+        _mm_setr_epi8(4, 5, 10, 11, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i gmask0 =
+        _mm_setr_epi8(2, 3, 8, 9, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i gmask1 =
+        _mm_setr_epi8(4, 5, 10, 11, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i gmask2 =
+        _mm_setr_epi8(0, 1, 6, 7, 12, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i bmask0 =
+        _mm_setr_epi8(4, 5, 10, 11, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i bmask1 =
+        _mm_setr_epi8(0, 1, 6, 7, 12, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i bmask2 =
+        _mm_setr_epi8(2, 3, 8, 9, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+
+    const __m128i low8 =
+        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, -1, -1, -1, -1, -1, -1, -1, -1);
+
+    size_t i = 0;
+    for (; i + 8 <= count; i += 8)
+    {
+        __builtin_prefetch(src + i * 3 + 24);
+        const __m128i t0 = _mm_loadu_si128((const __m128i *)(src + i * 3));
+        const __m128i t1 = _mm_loadu_si128((const __m128i *)(src + i * 3 + 8));
+        const __m128i t2 = _mm_loadu_si128((const __m128i *)(src + i * 3 + 16));
+
+        __m128i r = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, rmask0),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, rmask1), 6)),
+            _mm_slli_si128(_mm_shuffle_epi8(t2, rmask2), 12));
+        __m128i g = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, gmask0),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, gmask1), 4)),
+            _mm_slli_si128(_mm_shuffle_epi8(t2, gmask2), 10));
+        __m128i b = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, bmask0),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, bmask1), 4)),
+            _mm_slli_si128(_mm_shuffle_epi8(t2, bmask2), 10));
+
+        r = _mm_srli_epi16(r, 8);
+        g = _mm_srli_epi16(g, 8);
+        b = _mm_srli_epi16(b, 8);
+        __m128i r8 = _mm_shuffle_epi8(_mm_packus_epi16(r, r), low8);
+        __m128i g8 = _mm_shuffle_epi8(_mm_packus_epi16(g, g), low8);
+        __m128i b8 = _mm_shuffle_epi8(_mm_packus_epi16(b, b), low8);
+
+        __m128i rg = _mm_unpacklo_epi8(r8, g8);
+        __m128i ba = _mm_unpacklo_epi8(b8, alpha);
+        _mm_storeu_si128((__m128i *)(dst + i + 0),
+                         _mm_unpacklo_epi16(rg, ba));
+        _mm_storeu_si128((__m128i *)(dst + i + 4),
+                         _mm_unpackhi_epi16(rg, ba));
+    }
+    if (i < count)
+        pack_rgb48_scalar(src + i * 3, dst + i, count - i);
+}
+
+static void pack_rgba64_sse41(const uint16_t *src, uint32_t *dst, size_t count)
+{
+    const __m128i rmask =
+        _mm_setr_epi8(0, 1, 8, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    const __m128i gmask =
+        _mm_setr_epi8(2, 3, 10, 11, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                      -1);
+    const __m128i bmask =
+        _mm_setr_epi8(4, 5, 12, 13, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                      -1);
+    const __m128i amask =
+        _mm_setr_epi8(6, 7, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                      -1);
+    const __m128i alpha_mask =
+        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, -1, -1, -1, -1, -1, -1, -1, -1);
+
+    size_t i = 0;
+    for (; i + 8 <= count; i += 8)
+    {
+        __builtin_prefetch(src + i * 4 + 32);
+        __m128i t0 = _mm_loadu_si128((const __m128i *)(src + i * 4));
+        __m128i t1 = _mm_loadu_si128((const __m128i *)(src + i * 4 + 8));
+        __m128i t2 = _mm_loadu_si128((const __m128i *)(src + i * 4 + 16));
+        __m128i t3 = _mm_loadu_si128((const __m128i *)(src + i * 4 + 24));
+
+        __m128i r = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, rmask),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, rmask), 4)),
+            _mm_or_si128(_mm_slli_si128(_mm_shuffle_epi8(t2, rmask), 8),
+                         _mm_slli_si128(_mm_shuffle_epi8(t3, rmask), 12)));
+        __m128i g = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, gmask),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, gmask), 4)),
+            _mm_or_si128(_mm_slli_si128(_mm_shuffle_epi8(t2, gmask), 8),
+                         _mm_slli_si128(_mm_shuffle_epi8(t3, gmask), 12)));
+        __m128i b = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, bmask),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, bmask), 4)),
+            _mm_or_si128(_mm_slli_si128(_mm_shuffle_epi8(t2, bmask), 8),
+                         _mm_slli_si128(_mm_shuffle_epi8(t3, bmask), 12)));
+        __m128i a = _mm_or_si128(
+            _mm_or_si128(_mm_shuffle_epi8(t0, amask),
+                         _mm_slli_si128(_mm_shuffle_epi8(t1, amask), 4)),
+            _mm_or_si128(_mm_slli_si128(_mm_shuffle_epi8(t2, amask), 8),
+                         _mm_slli_si128(_mm_shuffle_epi8(t3, amask), 12)));
+
+        r = _mm_srli_epi16(r, 8);
+        g = _mm_srli_epi16(g, 8);
+        b = _mm_srli_epi16(b, 8);
+        a = _mm_srli_epi16(a, 8);
+        __m128i r8 = _mm_shuffle_epi8(_mm_packus_epi16(r, r), alpha_mask);
+        __m128i g8 = _mm_shuffle_epi8(_mm_packus_epi16(g, g), alpha_mask);
+        __m128i b8 = _mm_shuffle_epi8(_mm_packus_epi16(b, b), alpha_mask);
+        __m128i a8 = _mm_shuffle_epi8(_mm_packus_epi16(a, a), alpha_mask);
+
+        __m128i rg = _mm_unpacklo_epi8(r8, g8);
+        __m128i ba = _mm_unpacklo_epi8(b8, a8);
+        _mm_storeu_si128((__m128i *)(dst + i + 0),
+                         _mm_unpacklo_epi16(rg, ba));
+        _mm_storeu_si128((__m128i *)(dst + i + 4),
+                         _mm_unpackhi_epi16(rg, ba));
+    }
+    if (i < count)
+        pack_rgba64_scalar(src + i * 4, dst + i, count - i);
+}
+#endif
 #if defined(HAVE_NEON) && defined(__ARM_NEON)
 static void pack_rgb24_neon(const uint8_t *src, uint32_t *dst, size_t count)
 {
@@ -113,6 +329,11 @@ void TIFFPackRGB24(const uint8_t *src, uint32_t *dst, size_t count)
         pack_rgb24_neon(src, dst, count);
     else
 #endif
+#if defined(HAVE_SSE41)
+    if (tiff_use_sse41)
+        pack_rgb24_sse41(src, dst, count);
+    else
+#endif
         pack_rgb24_scalar(src, dst, count);
 }
 
@@ -121,6 +342,11 @@ void TIFFPackRGBA32(const uint8_t *src, uint32_t *dst, size_t count)
 #if defined(HAVE_NEON) && defined(__ARM_NEON)
     if (tiff_use_neon)
         pack_rgba32_neon(src, dst, count);
+    else
+#endif
+#if defined(HAVE_SSE41)
+    if (tiff_use_sse41)
+        pack_rgba32_sse41(src, dst, count);
     else
 #endif
         pack_rgba32_scalar(src, dst, count);
@@ -133,6 +359,11 @@ void TIFFPackRGB48(const uint16_t *src, uint32_t *dst, size_t count)
         pack_rgb48_neon(src, dst, count);
     else
 #endif
+#if defined(HAVE_SSE41)
+    if (tiff_use_sse41)
+        pack_rgb48_sse41(src, dst, count);
+    else
+#endif
         pack_rgb48_scalar(src, dst, count);
 }
 
@@ -141,6 +372,11 @@ void TIFFPackRGBA64(const uint16_t *src, uint32_t *dst, size_t count)
 #if defined(HAVE_NEON) && defined(__ARM_NEON)
     if (tiff_use_neon)
         pack_rgba64_neon(src, dst, count);
+    else
+#endif
+#if defined(HAVE_SSE41)
+    if (tiff_use_sse41)
+        pack_rgba64_sse41(src, dst, count);
     else
 #endif
         pack_rgba64_scalar(src, dst, count);


### PR DESCRIPTION
## Summary
- implement SSE4.1 versions of RGB packing helpers
- dispatch to SSE4.1 when available

## Testing
- `cmake ..` *(fails: missing CharLS)*
- `cmake --build . -j$(nproc)` *(fails: ISA option -mssse3 not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68503f879b488321b777421ddba2d038