### PR TITLE
Add SSE4.1 strip assembly and SIMD wrapper

### DIFF
--- a/doc/async_dng.rst
+++ b/doc/async_dng.rst
@@ -19,7 +19,7 @@ the next strip is prepared::
 
     _tiffUringSetAsync(tif, 1);
     for (...) {
-        TIFFAssembleStripNEON(tif, src, w, rows, 1, 1, &sz, tmp, buf);
+        TIFFAssembleStripSIMD(tif, src, w, rows, 1, 1, &sz, tmp, buf);
         _tiffUringWriteProc((thandle_t)TIFFFileno(tif), buf, (tmsize_t)sz);
     }
     _TIFFThreadPoolWait(pool);

--- a/libtiff/CMakeLists.txt
+++ b/libtiff/CMakeLists.txt
@@ -49,6 +49,8 @@ set(tiff_private_HEADERS
         tif_bayer.h
         rgb_neon.h
         strip_neon.h
+        strip_sse41.h
+        strip_simd.h
         reverse_bits_neon.h
         ${CMAKE_CURRENT_BINARY_DIR}/tif_config.h)
 
@@ -94,6 +96,8 @@ target_sources(tiff PRIVATE
         tif_strip.c
         tif_swab.c
         tif_strip_neon.c
+        tif_strip_sse41.c
+        tif_strip_simd.c
         tiff_simd.c
         tif_thunder.c
         tif_tile.c

--- a/libtiff/Makefile.am
+++ b/libtiff/Makefile.am
@@ -56,6 +56,8 @@ noinst_HEADERS = \
         tif_bayer.h \
         rgb_neon.h \
         strip_neon.h \
+        strip_sse41.h \
+        strip_simd.h \
         reverse_bits_neon.h
 
 nodist_libtiffinclude_HEADERS = \
@@ -96,7 +98,9 @@ libtiff_la_SOURCES = \
        tif_read.c \
       tif_strip.c \
       tif_strip_neon.c \
-       tiff_simd.c \
+      tif_strip_sse41.c \
+      tif_strip_simd.c \
+      tiff_simd.c \
       tif_swab.c \
         tif_thunder.c \
         tif_tile.c \

--- a/libtiff/libtiff.def
+++ b/libtiff/libtiff.def
@@ -206,6 +206,8 @@ EXPORTS	TIFFAccessTagMethods
         TIFFPackRaw16
         TIFFUnpackRaw16
         TIFFAssembleStripNEON
+        TIFFAssembleStripSSE41
+        TIFFAssembleStripSIMD
         TIFFPackRGB24
         TIFFPackRGBA32
         TIFFPackRGB48

--- a/libtiff/libtiff.map
+++ b/libtiff/libtiff.map
@@ -232,6 +232,8 @@ LIBTIFF_4.7.1 {
     TIFFPackRaw16;
     TIFFUnpackRaw16;
     TIFFAssembleStripNEON;
+    TIFFAssembleStripSSE41;
+    TIFFAssembleStripSIMD;
     TIFFPackRGB24;
     TIFFPackRGBA32;
     TIFFPackRGB48;

--- a/libtiff/strip_simd.h
+++ b/libtiff/strip_simd.h
@@ -1,0 +1,23 @@
+#ifndef STRIP_SIMD_H
+#define STRIP_SIMD_H
+
+#include "tiffio.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    uint8_t *TIFFAssembleStripSIMD(TIFF *tif, const uint16_t *src,
+                                   uint32_t width, uint32_t height,
+                                   int apply_predictor, int bigendian,
+                                   size_t *out_size, uint16_t *scratch,
+                                   uint8_t *out_buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STRIP_SIMD_H */

--- a/libtiff/strip_sse41.h
+++ b/libtiff/strip_sse41.h
@@ -1,0 +1,23 @@
+#ifndef STRIP_SSE41_H
+#define STRIP_SSE41_H
+
+#include "tiffio.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    uint8_t *TIFFAssembleStripSSE41(TIFF *tif, const uint16_t *src,
+                                    uint32_t width, uint32_t height,
+                                    int apply_predictor, int bigendian,
+                                    size_t *out_size, uint16_t *scratch,
+                                    uint8_t *out_buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STRIP_SSE41_H */

--- a/libtiff/tif_strip_simd.c
+++ b/libtiff/tif_strip_simd.c
@@ -1,0 +1,31 @@
+#include "strip_neon.h"
+#include "strip_sse41.h"
+#include "tiff_simd.h"
+
+uint8_t *TIFFAssembleStripSIMD(TIFF *tif, const uint16_t *src, uint32_t width,
+                               uint32_t height, int apply_predictor,
+                               int bigendian, size_t *out_size,
+                               uint16_t *scratch, uint8_t *out_buf)
+{
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+    if (TIFFUseNEON())
+        return TIFFAssembleStripNEON(tif, src, width, height, apply_predictor,
+                                     bigendian, out_size, scratch, out_buf);
+#endif
+#if defined(HAVE_SSE41)
+    if (TIFFUseSSE41())
+        return TIFFAssembleStripSSE41(tif, src, width, height, apply_predictor,
+                                      bigendian, out_size, scratch, out_buf);
+#endif
+#if defined(HAVE_NEON) && defined(__ARM_NEON)
+    return TIFFAssembleStripNEON(tif, src, width, height, apply_predictor,
+                                 bigendian, out_size, scratch, out_buf);
+#elif defined(HAVE_SSE41)
+    return TIFFAssembleStripSSE41(tif, src, width, height, apply_predictor,
+                                  bigendian, out_size, scratch, out_buf);
+#else
+    /* Scalar path compiled in NEON implementation */
+    return TIFFAssembleStripNEON(tif, src, width, height, apply_predictor,
+                                 bigendian, out_size, scratch, out_buf);
+#endif
+}

--- a/libtiff/tif_strip_sse41.c
+++ b/libtiff/tif_strip_sse41.c
@@ -1,0 +1,154 @@
+#include "tif_bayer.h"
+#include "tiff_simd.h"
+#include "tiffiop.h"
+#include <stdbool.h>
+#include <string.h>
+#if defined(HAVE_SSE41)
+#include <smmintrin.h>
+#endif
+
+static void horiz_diff16(uint16_t *row, uint32_t width)
+{
+#if defined(HAVE_SSE41)
+    if (tiff_use_sse41)
+    {
+        if (width <= 1)
+            return;
+        uint16_t *p = row + 1;
+        uint32_t remaining = width - 1;
+        __m128i prev = _mm_set1_epi16((short)row[0]);
+        while (remaining >= 8)
+        {
+            __m128i cur = _mm_loadu_si128((const __m128i *)p);
+            __m128i prev_vec = _mm_alignr_epi8(cur, prev, 2);
+            __m128i diff = _mm_sub_epi16(cur, prev_vec);
+            _mm_storeu_si128((__m128i *)p, diff);
+            prev = cur;
+            p += 8;
+            remaining -= 8;
+        }
+        uint16_t acc = (uint16_t)_mm_extract_epi16(prev, 7);
+        while (remaining--)
+        {
+            uint16_t curWord = *p;
+            *p = (uint16_t)(curWord - acc);
+            acc = curWord;
+            ++p;
+        }
+        return;
+    }
+#endif
+    if (width <= 1)
+        return;
+    for (uint32_t i = 1; i < width; i++)
+        row[i] = (uint16_t)(row[i] - row[i - 1]);
+}
+
+typedef struct
+{
+    TIFF *tif;
+    const uint16_t *src;
+    uint32_t width;
+    uint32_t height;
+    int apply_predictor;
+    int bigendian;
+    size_t *out_size;
+    uint16_t *scratch;
+    uint8_t *out_buf;
+    uint8_t *result;
+} TPStripTask;
+
+static uint8_t *assemble_strip_sse41_internal(TIFF *tif, const uint16_t *src,
+                                              uint32_t width, uint32_t height,
+                                              int apply_predictor,
+                                              int bigendian, size_t *out_size,
+                                              uint16_t *scratch,
+                                              uint8_t *out_buf);
+
+static void assemble_strip_sse41_task(void *arg)
+{
+    TPStripTask *t = (TPStripTask *)arg;
+    t->result = assemble_strip_sse41_internal(
+        t->tif, t->src, t->width, t->height, t->apply_predictor, t->bigendian,
+        t->out_size, t->scratch, t->out_buf);
+}
+
+uint8_t *TIFFAssembleStripSSE41(TIFF *tif, const uint16_t *src, uint32_t width,
+                                uint32_t height, int apply_predictor,
+                                int bigendian, size_t *out_size,
+                                uint16_t *scratch, uint8_t *out_buf)
+{
+    static const char module[] = "TIFFAssembleStripSSE41";
+    TPStripTask task = {tif,       src,      width,   height,  apply_predictor,
+                        bigendian, out_size, scratch, out_buf, NULL};
+#ifdef TIFF_USE_THREADPOOL
+    if (tif && TIFFGetThreadCount(tif) > 1)
+    {
+        _TIFFThreadPoolSubmit(tif->tif_threadpool, assemble_strip_sse41_task,
+                              &task);
+        _TIFFThreadPoolWait(tif->tif_threadpool);
+        return task.result;
+    }
+#endif
+    return assemble_strip_sse41_internal(tif, src, width, height,
+                                         apply_predictor, bigendian, out_size,
+                                         scratch, out_buf);
+}
+
+static uint8_t *assemble_strip_sse41_internal(TIFF *tif, const uint16_t *src,
+                                              uint32_t width, uint32_t height,
+                                              int apply_predictor,
+                                              int bigendian, size_t *out_size,
+                                              uint16_t *scratch,
+                                              uint8_t *out_buf)
+{
+    static const char module[] = "TIFFAssembleStripSSE41";
+    uint64_t count64 = _TIFFMultiply64(tif, width, height, module);
+    if (count64 == 0 && width != 0 && height != 0)
+        return NULL;
+    tmsize_t countm = _TIFFCastUInt64ToSSize(tif, count64, module);
+    if (countm == 0 && count64 != 0)
+        return NULL;
+    size_t count = (size_t)countm;
+
+    bool free_scratch = false;
+    if (apply_predictor && scratch == NULL)
+    {
+        scratch = (uint16_t *)_TIFFmallocExt(tif, count * sizeof(uint16_t));
+        if (!scratch)
+        {
+            TIFFErrorExtR(tif, module, "Out of memory");
+            return NULL;
+        }
+        free_scratch = true;
+    }
+    if (apply_predictor)
+    {
+        memcpy(scratch, src, count * sizeof(uint16_t));
+        for (uint32_t row = 0; row < height; row++)
+            horiz_diff16(scratch + row * width, width);
+    }
+
+    size_t packed_size = ((count + 1) / 2) * 3;
+    if (out_buf == NULL)
+    {
+        out_buf = (uint8_t *)_TIFFmallocExt(tif, packed_size);
+        if (!out_buf)
+        {
+            if (free_scratch)
+                _TIFFfreeExt(tif, scratch);
+            TIFFErrorExtR(tif, module, "Out of memory");
+            return NULL;
+        }
+    }
+
+    const uint16_t *pack_src = apply_predictor ? scratch : src;
+    TIFFPackRaw12(pack_src, out_buf, count, bigendian);
+
+    if (free_scratch)
+        _TIFFfreeExt(tif, scratch);
+
+    if (out_size)
+        *out_size = packed_size;
+    return out_buf;
+}

--- a/test/assemble_strip_neon_test.c
+++ b/test/assemble_strip_neon_test.c
@@ -1,4 +1,4 @@
-#include "strip_neon.h"
+#include "strip_simd.h"
 #include "tiffio.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,7 +16,7 @@ int main(void)
         buf[i] = (uint16_t)i;
 
     size_t strip_size = 0;
-    uint8_t *strip = TIFFAssembleStripNEON(NULL, buf, width, height, 0, 1,
+    uint8_t *strip = TIFFAssembleStripSIMD(NULL, buf, width, height, 0, 1,
                                            &strip_size, NULL, NULL);
     free(buf);
     if (!strip)

--- a/test/pack_uring_benchmark.c
+++ b/test/pack_uring_benchmark.c
@@ -1,4 +1,4 @@
-#include "strip_neon.h"
+#include "strip_simd.h"
 #include "tiffio.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,7 +24,7 @@ int main(void)
         src[i] = (uint16_t)(i & 0x0FFF);
 
     size_t strip_size = 0;
-    uint8_t *packed = TIFFAssembleStripNEON(NULL, src, width, height, 1, 0,
+    uint8_t *packed = TIFFAssembleStripSIMD(NULL, src, width, height, 1, 0,
                                             &strip_size, NULL, NULL);
 
     struct timespec s, e;

--- a/test/predictor_threadpool_benchmark.c
+++ b/test/predictor_threadpool_benchmark.c
@@ -1,4 +1,4 @@
-#include "strip_neon.h"
+#include "strip_simd.h"
 #include "tiff_threadpool.h"
 #include "tiffiop.h"
 #include <stdio.h>
@@ -25,7 +25,7 @@ static void bench_task(void *arg)
     for (size_t i = 0; i < t->loops; i++)
     {
         size_t out_size = 0;
-        uint8_t *dst = TIFFAssembleStripNEON(NULL, t->src, t->width, t->height,
+        uint8_t *dst = TIFFAssembleStripSIMD(NULL, t->src, t->width, t->height,
                                              1, 0, &out_size, NULL, NULL);
         if (!dst)
             continue;

--- a/test/predictor_threadpool_resize.c
+++ b/test/predictor_threadpool_resize.c
@@ -1,4 +1,4 @@
-#include "strip_neon.h"
+#include "strip_simd.h"
 #include "tiff_threadpool.h"
 #include "tiffiop.h"
 #include <stdio.h>
@@ -20,7 +20,7 @@ static void bench_task(void *arg)
     for (size_t i = 0; i < t->loops; i++)
     {
         size_t out_size = 0;
-        uint8_t *dst = TIFFAssembleStripNEON(NULL, t->src, t->width, t->height,
+        uint8_t *dst = TIFFAssembleStripSIMD(NULL, t->src, t->width, t->height,
                                              1, 0, &out_size, NULL, NULL);
         free(dst);
     }


### PR DESCRIPTION
## Summary
- implement SSE4.1 versions of horiz_diff16 and strip assembly
- create `TIFFAssembleStripSIMD` wrapper to select NEON or SSE4.1
- add new public headers and update build files
- update docs and tests to use the new API

## Testing
- `pre-commit run --files libtiff/strip_sse41.h libtiff/strip_simd.h libtiff/tif_strip_sse41.c libtiff/tif_strip_simd.c libtiff/Makefile.am libtiff/CMakeLists.txt libtiff/libtiff.map libtiff/libtiff.def README.md doc/async_dng.rst test/assemble_strip_neon_test.c test/assemble_strip_neon_alloc_fail.c test/predictor_threadpool_benchmark.c test/predictor_threadpool_resize.c test/pack_uring_benchmark.c libtiff/tif_strip_neon.c`
- `cmake -S . -B build -DCMAKE_C_FLAGS="-msse4.1"`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure` *(fails: tiffcrop and addtiffo tests)*

------
https://chatgpt.com/codex/tasks/task_e_685043686b488321af0b33f62c02a4d3