### PR TITLE
Fix SSE compilation and export SIMD flags

### DIFF
--- a/cmake/ProcessorChecks.cmake
+++ b/cmake/ProcessorChecks.cmake
@@ -72,6 +72,21 @@ if(HAVE_ARM_CRC32)
   add_compile_definitions(HAVE_ARM_CRC32=1)
 endif()
 
+# Determine SSE flags
+set(TIFF_SSE_FLAGS "" CACHE STRING "Flags used to enable SSE instructions")
+set(_sse41_flags "${TIFF_SSE_FLAGS}")
+set(_sse42_flags "${TIFF_SSE_FLAGS}")
+if(NOT _sse41_flags)
+  if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+    set(_sse41_flags "-msse4.1")
+  endif()
+endif()
+if(NOT _sse42_flags)
+  if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+    set(_sse42_flags "-msse4.2")
+  endif()
+endif()
+
 check_c_source_compiles(
   "#include <emmintrin.h>
    int main(){ __m128i v = _mm_setzero_si128(); return _mm_cvtsi128_si32(v); }"
@@ -86,6 +101,9 @@ check_c_source_compiles(
   HAVE_SSE41)
 if(HAVE_SSE41)
   add_compile_definitions(HAVE_SSE41=1)
+  if(_sse41_flags)
+    add_compile_options("${_sse41_flags}")
+  endif()
 endif()
 
 check_c_source_compiles(
@@ -94,4 +112,7 @@ check_c_source_compiles(
   HAVE_SSE42)
 if(HAVE_SSE42)
   add_compile_definitions(HAVE_SSE42=1)
+  if(_sse42_flags)
+    add_compile_options("${_sse42_flags}")
+  endif()
 endif()

--- a/libtiff/libtiff.map
+++ b/libtiff/libtiff.map
@@ -247,6 +247,10 @@ LIBTIFF_4.7.1 {
     TIFFSetThreadPoolSize;
     TIFFGetThreadCount;
     TIFFInitSIMD;
+    tiff_use_neon;
+    tiff_use_sse41;
+    tiff_use_sse2;
+    tiff_use_sse42;
     TIFFUseNEON;
     TIFFUseSSE41;
     TIFFUseSSE2;


### PR DESCRIPTION
## Summary
- add SSE4 compiler flags when detected
- export SIMD control variables in the version script

## Testing
- `ctest` *(fails: Error writing TIFF header)*

------
https://chatgpt.com/codex/tasks/task_e_68504f0e7430832184a34d080c2c4408