### PR TITLE
Enable thread pool macro for CMake builds

### DIFF
--- a/cmake/ThreadPool.cmake
+++ b/cmake/ThreadPool.cmake
@@ -1,6 +1,7 @@
 # Thread pool support
 option(threadpool "enable internal thread pool" OFF)
 set(TIFF_THREADPOOL ${threadpool})
+set(TIFF_USE_THREADPOOL ${threadpool})
 if(TIFF_THREADPOOL)
     find_package(Threads REQUIRED)
     list(APPEND tiff_libs_private_list "${CMAKE_THREAD_LIBS_INIT}")

--- a/libtiff/tif_read.c
+++ b/libtiff/tif_read.c
@@ -28,6 +28,9 @@
  */
 #include "tiff_simd.h"
 #include "tiffiop.h"
+#ifdef TIFF_USE_THREADPOOL
+#include "tiff_threadpool.h"
+#endif
 #include <stdio.h>
 
 int TIFFFillStrip(TIFF *tif, uint32_t strip);


### PR DESCRIPTION
## Summary
- wire up `TIFF_USE_THREADPOOL` in CMake to propagate to headers
- include `tiff_threadpool.h` when building with thread pool support

## Testing
- `cmake -S . -B build-cmake -DBUILD_TESTING=ON -Dthreadpool=ON`
- `cmake --build build-cmake -j $(nproc)`
- `ctest --output-on-failure` *(fails: Error writing TIFF header)*

------
https://chatgpt.com/codex/tasks/task_e_68505cff03fc832185326cac9e2ec14a