### PR TITLE
Add input override to BigTIFF roundtrip test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,6 +125,12 @@ set_target_properties(test_open_jpeg_dng PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(test_open_jpeg_dng PRIVATE tiff tiff_port)
 list(APPEND simple_tests test_open_jpeg_dng)
 
+add_executable(test_bigtiff_roundtrip ../placeholder.h)
+target_sources(test_bigtiff_roundtrip PRIVATE test_bigtiff_roundtrip.c)
+set_target_properties(test_bigtiff_roundtrip PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(test_bigtiff_roundtrip PRIVATE tiff tiff_port)
+list(APPEND simple_tests test_bigtiff_roundtrip)
+
 add_executable(long_tag ../placeholder.h)
 target_sources(long_tag PRIVATE long_tag.c check_tag.c)
 set_target_properties(long_tag PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -96,7 +96,7 @@ JPEGLS_DEPENDENT_TESTSCRIPTS_TO_RUN=
 endif
 
 if BUILD_STATIC
-STATIC_CHECK_PROGS=rational_precision2double test_write_read_tags test_transferfunction_write_read test_open_jpeg_dng
+STATIC_CHECK_PROGS=rational_precision2double test_write_read_tags test_transferfunction_write_read test_open_jpeg_dng test_bigtiff_roundtrip
 endif
 
 # Executable programs which need to be built in order to support tests
@@ -109,7 +109,7 @@ check_PROGRAMS = \
        rgb_pack_neon_test \
        bayer_neon_test \
        packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize ycbcr_neon_test predictor_sse41_test \
-       test_open_jpeg_dng
+       test_open_jpeg_dng test_bigtiff_roundtrip
 endif
 
 # Test scripts to execute
@@ -132,8 +132,10 @@ BASE_TESTSCRIPTS = \
         tiffcp-jpeg-invalid.sh \
         tiffcp-invalid-compression.sh \
         tiffdump.sh \
-	tiffinfo.sh \
-	tiffcp-split.sh \
+        tiffinfo.sh \
+        tiffdump-jpeg-big.sh \
+        tiffinfo-jpeg-big.sh \
+        tiffcp-split.sh \
 	tiffcp-split-join.sh \
 	tiff2ps-PS1.sh \
 	tiff2ps-PS2.sh \
@@ -369,6 +371,9 @@ predictor_sse41_test_LDADD = $(LIBTIFF)
 
 test_open_jpeg_dng_SOURCES = test_open_jpeg_dng.c
 test_open_jpeg_dng_LDADD = $(LIBTIFF)
+
+test_bigtiff_roundtrip_SOURCES = test_bigtiff_roundtrip.c
+test_bigtiff_roundtrip_LDADD = $(LIBTIFF)
 
 predictor_threadpool_benchmark_SOURCES = predictor_threadpool_benchmark.c
 predictor_threadpool_benchmark_LDADD = $(LIBTIFF)

--- a/test/gen_bigtiff_from_jpeg.py
+++ b/test/gen_bigtiff_from_jpeg.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import sys
+import subprocess
+import os
+
+try:
+    from PIL import Image
+except Exception:
+    sys.stderr.write("Pillow is required. Install with 'pip install pillow'.\n")
+    sys.exit(1)
+
+
+def main(src, dst, tiffcp):
+    tmp = dst + ".tmp.tif"
+    Image.open(src).save(tmp, format="TIFF")
+    subprocess.run([tiffcp, '-8', tmp, dst], check=True)
+    os.remove(tmp)
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print("Usage: gen_bigtiff_from_jpeg.py INPUT.jpg OUTPUT.tif TIFFCP", file=sys.stderr)
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/test/test_bigtiff_roundtrip.c
+++ b/test/test_bigtiff_roundtrip.c
@@ -1,0 +1,112 @@
+#include "tif_config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include "tiffio.h"
+
+int main(int argc, char **argv)
+{
+    char path[1024];
+    const char *filepath = NULL;
+    if (argc >= 2)
+    {
+        filepath = argv[1];
+    }
+    else
+    {
+        filepath = getenv("BIGTIFF_FILE");
+        if (!filepath)
+        {
+            const char *rel = "images/TEST_JPEG_BIG.tif";
+            char *srcdir = getenv("srcdir");
+            if (!srcdir)
+                srcdir = ".";
+            snprintf(path, sizeof(path), "%s/%s", srcdir, rel);
+            filepath = path;
+        }
+    }
+
+    TIFF *in = TIFFOpen(filepath, "r");
+    if (!in)
+    {
+        fprintf(stderr, "Cannot open %s\n", filepath);
+        return 1;
+    }
+    if (!TIFFIsBigTIFF(in))
+    {
+        fprintf(stderr, "Input is not BigTIFF\n");
+        TIFFClose(in);
+        return 1;
+    }
+
+    uint32_t width = 0, length = 0;
+    uint16_t spp = 0, bps = 0, photo = 0;
+    TIFFGetField(in, TIFFTAG_IMAGEWIDTH, &width);
+    TIFFGetField(in, TIFFTAG_IMAGELENGTH, &length);
+    TIFFGetField(in, TIFFTAG_SAMPLESPERPIXEL, &spp);
+    TIFFGetField(in, TIFFTAG_BITSPERSAMPLE, &bps);
+    TIFFGetField(in, TIFFTAG_PHOTOMETRIC, &photo);
+
+    tsize_t scanline = TIFFScanlineSize(in);
+    tdata_t buf = _TIFFmalloc(scanline);
+    if (!buf)
+    {
+        fprintf(stderr, "Out of memory\n");
+        TIFFClose(in);
+        return 1;
+    }
+
+    const char *outfile = "roundtrip_big.tif";
+    TIFF *out = TIFFOpen(outfile, "w8");
+    if (!out)
+    {
+        fprintf(stderr, "Cannot create %s\n", outfile);
+        _TIFFfree(buf);
+        TIFFClose(in);
+        return 1;
+    }
+    TIFFSetField(out, TIFFTAG_IMAGEWIDTH, width);
+    TIFFSetField(out, TIFFTAG_IMAGELENGTH, length);
+    TIFFSetField(out, TIFFTAG_SAMPLESPERPIXEL, spp);
+    TIFFSetField(out, TIFFTAG_BITSPERSAMPLE, bps);
+    TIFFSetField(out, TIFFTAG_PHOTOMETRIC, photo);
+    TIFFSetField(out, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    TIFFSetField(out, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
+    TIFFSetField(out, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(out, 0));
+
+    for (uint32_t y = 0; y < length; y++)
+    {
+        if (TIFFReadScanline(in, buf, y, 0) == -1 ||
+            TIFFWriteScanline(out, buf, y, 0) == -1)
+        {
+            fprintf(stderr, "Read/write error at line %u\n", y);
+            TIFFClose(out);
+            _TIFFfree(buf);
+            TIFFClose(in);
+            unlink(outfile);
+            return 1;
+        }
+    }
+    _TIFFfree(buf);
+    TIFFClose(in);
+    TIFFClose(out);
+
+    out = TIFFOpen(outfile, "r");
+    if (!out)
+    {
+        fprintf(stderr, "Cannot reopen %s\n", outfile);
+        return 1;
+    }
+    int isBig = TIFFIsBigTIFF(out);
+    uint32_t rwidth = 0, rlength = 0;
+    TIFFGetField(out, TIFFTAG_IMAGEWIDTH, &rwidth);
+    TIFFGetField(out, TIFFTAG_IMAGELENGTH, &rlength);
+    TIFFClose(out);
+    unlink(outfile);
+    if (!isBig || rwidth != width || rlength != length)
+        return 1;
+    return 0;
+}

--- a/test/tiffdump-jpeg-big.sh
+++ b/test/tiffdump-jpeg-big.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+. ${srcdir:-.}/common.sh
+outfile="${TMPDIR:-/tmp}/TEST_JPEG_BIG.tif"
+python3 "$SRCDIR/gen_bigtiff_from_jpeg.py" "$IMG_TEST_JPEG" "$outfile" "$TIFFCP"
+f_test_reader "${TIFFDUMP}" "$outfile"
+rm -f "$outfile"

--- a/test/tiffinfo-jpeg-big.sh
+++ b/test/tiffinfo-jpeg-big.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+. ${srcdir:-.}/common.sh
+outfile="${TMPDIR:-/tmp}/TEST_JPEG_BIG.tif"
+python3 "$SRCDIR/gen_bigtiff_from_jpeg.py" "$IMG_TEST_JPEG" "$outfile" "$TIFFCP"
+f_test_reader "${TIFFINFO} -D" "$outfile"
+rm -f "$outfile"


### PR DESCRIPTION
## Summary
- allow passing BigTIFF path to the roundtrip tester via argv or environment
- create `gen_bigtiff_from_jpeg.py` to convert JPEG sample into BigTIFF
- update test scripts to generate the BigTIFF image at runtime
- remove the binary BigTIFF sample from repo

## Testing
- `pre-commit run --files test/CMakeLists.txt test/Makefile.am test/gen_bigtiff_from_jpeg.py test/tiffdump-jpeg-big.sh test/tiffinfo-jpeg-big.sh`
- `cmake --build build_out -j$(nproc)`
- `BIGTIFF_FILE=/tmp/generated_big.tif ctest -R test_bigtiff_roundtrip --output-on-failure`
- `./tools/tiffinfo /tmp/generated_big.tif | head -n 5`
- `./tools/tiffdump /tmp/generated_big.tif | head -n 6`


------
https://chatgpt.com/codex/tasks/task_e_68516b1aa15483219f7503dcf7710de7