### PR TITLE
Add runtime io_uring disable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,8 @@ API. The queue depth defaults to 8 but may be tuned through the
 `TIFF_URING_DEPTH` environment variable, via
 `TIFFOpenOptionsSetURingQueueDepth()` before opening a file, or at runtime with
 `TIFFSetURingQueueDepth()`. Any positive value accepted by the kernel is
-allowed.
+allowed. Set `TIFF_USE_IOURING=0` to force the portable thread fallback when
+the kernel or runtime environment does not support `io_uring`.
 
 ## Memory Mapping Tuning
 

--- a/doc/async_dng.rst
+++ b/doc/async_dng.rst
@@ -14,6 +14,9 @@ starts at eight. Tune it through the ``TIFF_URING_DEPTH`` environment
 variable, ``TIFFOpenOptionsSetURingQueueDepth()`` before opening a file,
 or at runtime with ``TIFFSetURingQueueDepth()``.
 
+Set ``TIFF_USE_IOURING=0`` to disable ``io_uring`` at runtime and fall
+back to the thread-based implementation when the kernel lacks support.
+
 An application typically assembles each strip and queues the write while
 the next strip is prepared::
 

--- a/libtiff/tif_uring.c
+++ b/libtiff/tif_uring.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <sys/uio.h>
 #ifdef USE_IO_URING
 #include <liburing.h>
@@ -350,6 +351,12 @@ static void _tiffUringRemove(int fd)
 int _tiffUringInit(TIFF *tif)
 {
     tif->tif_uring_is_thread = 0;
+    const char *env_use = getenv("TIFF_USE_IOURING");
+    if (env_use &&
+        (strcmp(env_use, "0") == 0 || strcasecmp(env_use, "no") == 0))
+    {
+        return _tiffUringThreadInit(tif);
+    }
     tif->tif_uring =
         (struct io_uring *)_TIFFmallocExt(tif, sizeof(struct io_uring));
     if (!tif->tif_uring)


### PR DESCRIPTION
## Summary
- allow disabling io_uring at runtime via `TIFF_USE_IOURING`
- document the new option in README and async DNG docs

## Testing
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build .`
- `ctest --output-on-failure test_signed_tags` *(fails: TEST_JPEG_BIG.tif missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851756e6b5483218480ddb014a951cf