### PR TITLE
Add tool tests for JPEG and DNG

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -141,8 +141,9 @@ BASE_TESTSCRIPTS = \
 	tiff2ps-PS2.sh \
 	tiff2ps-PS3.sh \
 	tiff2ps-EPS1.sh \
-	tiff2pdf.sh \
-	tiffcrop-doubleflip-logluv-3c-16b.sh \
+        tiff2pdf.sh \
+        tools-jpeg-dng.sh \
+        tiffcrop-doubleflip-logluv-3c-16b.sh \
 	tiffcrop-doubleflip-minisblack-1c-16b.sh \
 	tiffcrop-doubleflip-minisblack-1c-8b.sh \
 	tiffcrop-doubleflip-minisblack-2c-8b-alpha.sh \

--- a/test/tools-jpeg-dng.sh
+++ b/test/tools-jpeg-dng.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+. ${srcdir:-.}/common.sh
+
+jpeg="${IMAGES}/TEST_JPEG.jpg"
+dng="${IMAGES}/TEST_CINEPI_LIBTIFF_DNG.dng"
+tmpdir=${TMPDIR:-/tmp}
+
+expect_fail() {
+  if "$@"; then
+    echo "Unexpected success running $*"
+    exit 1
+  else
+    echo "Command failed as expected: $*"
+  fi
+}
+
+# tiffinfo
+expect_fail "${TIFFINFO}" "${jpeg}"
+f_test_reader "${TIFFINFO}" "${dng}"
+
+# tiffdump
+expect_fail "${TIFFDUMP}" "${jpeg}"
+f_test_reader "${TIFFDUMP}" "${dng}"
+
+# tiffcp
+outfile="${tmpdir}/tools-jpeg-dng.tiff"
+expect_fail "${TIFFCP}" "${jpeg}" "${outfile}"
+f_test_convert "${TIFFCP}" "${dng}" "${outfile}"
+"${TIFFCMP}" "${outfile}" "${dng}"
+rm -f "${outfile}"
+
+# tiffcrop
+outfile="${tmpdir}/tools-jpeg-dng-crop.tiff"
+expect_fail "${TIFFCROP}" "${jpeg}" "${outfile}"
+f_test_convert "${TIFFCROP} -U px -E top -X 10 -Y 10" "${dng}" "${outfile}"
+f_tiffinfo_validate "${outfile}"
+rm -f "${outfile}"
+
+# tiffset
+outfile="${tmpdir}/tools-jpeg-dng-set.tiff"
+cp "${dng}" "${outfile}"
+expect_fail "${TIFFSET}" -s 270 test "${jpeg}"
+"${TIFFSET}" -s 270 "desc" "${outfile}"
+"${TIFFINFO}" "${outfile}" | grep -q "desc"
+rm -f "${outfile}"
+
+# tiffsplit
+outfile_base="${tmpdir}/tools-jpeg-dng-split-"
+expect_fail "${TIFFSPLIT}" "${jpeg}" "${outfile_base}"
+"${TIFFSPLIT}" "${dng}" "${outfile_base}"
+f_tiffinfo_validate "${outfile_base}0.tif"
+rm -f "${outfile_base}"*.tif
+
+# tiff2pdf
+outfile="${tmpdir}/tools-jpeg-dng.pdf"
+expect_fail "${TIFF2PDF}" -o "${outfile}" "${jpeg}"
+"${TIFF2PDF}" -o "${outfile}" "${dng}"
+[ -s "${outfile}" ]
+rm -f "${outfile}"
+
+echo "All JPEG and DNG tool tests passed"
+


### PR DESCRIPTION
## Summary
- add a shell script exercising TIFF tools with JPEG and DNG images
- register the script in the autotools test suite

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure` *(fails: missing JPEG big test images)*

------
https://chatgpt.com/codex/tasks/task_e_68517ba45b548321a2c103d7a1fee9ea