### PR TITLE
Add SIMD compare test for DNG/JPEG

### DIFF
--- a/libtiff/tif_jpeg.c
+++ b/libtiff/tif_jpeg.c
@@ -212,6 +212,7 @@ typedef struct
 
 static int JPEGDecodeInternal(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s);
 static int JPEGDecodeRaw(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s);
+static int JPEGDecode(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s);
 static int JPEGEncode(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s);
 static int JPEGEncodeRaw(TIFF *tif, uint8_t *buf, tmsize_t cc, uint16_t s);
 static int JPEGInitializeLibJPEG(TIFF *tif, int decode);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -323,6 +323,12 @@ set_target_properties(bayer_neon_test PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(bayer_neon_test PRIVATE tiff tiff_port)
 list(APPEND simple_tests bayer_neon_test)
 
+add_executable(dng_simd_compare ../placeholder.h)
+target_sources(dng_simd_compare PRIVATE dng_simd_compare.c)
+set_target_properties(dng_simd_compare PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(dng_simd_compare PRIVATE tiff tiff_port)
+list(APPEND simple_tests dng_simd_compare)
+
 add_executable(predictor_sse41_test ../placeholder.h)
 target_sources(predictor_sse41_test PRIVATE predictor_sse41_test.c)
 set_target_properties(predictor_sse41_test PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -108,6 +108,7 @@ check_PROGRAMS = \
        bayer_simd_benchmark \
        rgb_pack_neon_test \
        bayer_neon_test \
+       dng_simd_compare \
        packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize ycbcr_neon_test predictor_sse41_test \
        test_open_jpeg_dng test_bigtiff_roundtrip
 endif
@@ -371,6 +372,9 @@ bayer_neon_test_LDADD = $(LIBTIFF)
 
 predictor_sse41_test_SOURCES = predictor_sse41_test.c
 predictor_sse41_test_LDADD = $(LIBTIFF)
+
+dng_simd_compare_SOURCES = dng_simd_compare.c
+dng_simd_compare_LDADD = $(LIBTIFF)
 
 test_open_jpeg_dng_SOURCES = test_open_jpeg_dng.c
 test_open_jpeg_dng_LDADD = $(LIBTIFF)

--- a/test/dng_simd_compare.c
+++ b/test/dng_simd_compare.c
@@ -1,0 +1,137 @@
+#include "tiffio.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+    TIFFInitSIMD();
+    uint32_t *ref = NULL;
+    uint32_t *simd = NULL;
+    size_t n = 0;
+    const char *rel = "images/TEST_CINEPI_LIBTIFF_DNG.dng";
+    char *srcdir = getenv("srcdir");
+    if (!srcdir)
+        srcdir = ".";
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s", srcdir, rel);
+
+    TIFF *tif = TIFFOpen(path, "r");
+    if (!tif)
+    {
+        /* If the DNG sample is unavailable or unreadable, fall back to a JPEG test */
+        const char *jpeg_rel = "images/TEST_JPEG.jpg";
+        char jpath[512];
+        snprintf(jpath, sizeof(jpath), "%s/%s", srcdir, jpeg_rel);
+        const char *script = "gen_bigtiff_from_jpeg.py";
+        char spath[512];
+        snprintf(spath, sizeof(spath), "%s/%s", srcdir, script);
+        const char *tiffcp = "../tools/tiffcp";
+        if (system(NULL) == 0)
+            return 1;
+        char cmd[1024];
+        snprintf(cmd, sizeof(cmd), "python3 %s %s jpeg_temp.tif %s", spath, jpath, tiffcp);
+        if (system(cmd) != 0)
+            return 1;
+        tif = TIFFOpen("jpeg_temp.tif", "r");
+        if (!tif)
+            return 1;
+    }
+    uint32_t w = 0, h = 0;
+    if (!TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &w) ||
+        !TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &h))
+    {
+        TIFFClose(tif);
+        return 1;
+    }
+    n = (size_t)w * h;
+    ref = (uint32_t *)malloc(n * sizeof(uint32_t));
+    simd = (uint32_t *)malloc(n * sizeof(uint32_t));
+    if (!ref || !simd)
+    {
+        TIFFClose(tif);
+        return 1;
+    }
+
+    int neon = TIFFUseNEON();
+    int sse = TIFFUseSSE41();
+
+    if (neon)
+        TIFFSetUseNEON(0);
+    if (sse)
+        TIFFSetUseSSE41(0);
+    if (!TIFFReadRGBAImage(tif, w, h, ref, 0))
+    {
+        /* reading DNG failed, try JPEG bigtiff fallback */
+        TIFFClose(tif);
+        const char *jpeg_rel = "images/TEST_JPEG.jpg";
+        char jpath[512];
+        snprintf(jpath, sizeof(jpath), "%s/%s", srcdir, jpeg_rel);
+        const char *script = "gen_bigtiff_from_jpeg.py";
+        char spath[512];
+        snprintf(spath, sizeof(spath), "%s/%s", srcdir, script);
+        const char *tiffcp = "../tools/tiffcp";
+        char cmd[1024];
+        snprintf(cmd, sizeof(cmd), "python3 %s %s jpeg_temp.tif %s", spath, jpath, tiffcp);
+        if (system(cmd) != 0)
+        {
+            free(ref);
+            free(simd);
+            return 1;
+        }
+        tif = TIFFOpen("jpeg_temp.tif", "r");
+        if (!tif)
+        {
+            free(ref);
+            free(simd);
+            return 1;
+        }
+        if (!TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &w) ||
+            !TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &h))
+        {
+            TIFFClose(tif);
+            free(ref);
+            free(simd);
+            return 1;
+        }
+        n = (size_t)w * h;
+        ref = (uint32_t *)realloc(ref, n * sizeof(uint32_t));
+        simd = (uint32_t *)realloc(simd, n * sizeof(uint32_t));
+        if (!ref || !simd)
+        {
+            TIFFClose(tif);
+            free(ref);
+            free(simd);
+            return 1;
+        }
+        if (!TIFFReadRGBAImage(tif, w, h, ref, 0))
+        {
+            TIFFClose(tif);
+            free(ref);
+            free(simd);
+            return 1;
+        }
+    }
+    if (neon)
+        TIFFSetUseNEON(1);
+    if (sse)
+        TIFFSetUseSSE41(1);
+    if (!TIFFReadRGBAImage(tif, w, h, simd, 0))
+    {
+        TIFFClose(tif);
+        free(ref);
+        free(simd);
+        return 1;
+    }
+    TIFFClose(tif);
+
+    int ret = memcmp(ref, simd, n * sizeof(uint32_t)) != 0;
+    if (ret)
+        fprintf(stderr, "SIMD output differs from scalar\n");
+
+    remove("jpeg_temp.tif");
+
+    free(ref);
+    free(simd);
+    return ret;
+}


### PR DESCRIPTION
## Summary
- add JPEG SIMD comparison test using DNG sample fallback
- declare missing JPEGDecode prototype to build with JPEG support

## Testing
- `cmake --build . -j$(nproc)`
- `ctest -R dng_simd_compare --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685184686a9c83218ac4e6585696d61e