### PR TITLE
Add failalloc test for DNG loading

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -404,6 +404,11 @@ target_sources(grow_strips_alloc_fail PRIVATE grow_strips_alloc_fail.c)
 target_link_libraries(grow_strips_alloc_fail PRIVATE tiff tiff_port failalloc)
 list(APPEND simple_tests grow_strips_alloc_fail)
 
+add_executable(open_dng_alloc_fail ../placeholder.h)
+target_sources(open_dng_alloc_fail PRIVATE open_dng_alloc_fail.c)
+target_link_libraries(open_dng_alloc_fail PRIVATE tiff tiff_port failalloc)
+list(APPEND simple_tests open_dng_alloc_fail)
+
 if(WEBP_SUPPORT AND EMSCRIPTEN)
   # Emscripten is pretty finnicky about linker flags.
   # It needs --shared-memory if and only if atomics or bulk-memory is used.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -110,7 +110,7 @@ check_PROGRAMS = \
        bayer_neon_test \
        dng_simd_compare \
        packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize ycbcr_neon_test predictor_sse41_test \
-       test_open_jpeg_dng test_bigtiff_roundtrip
+       test_open_jpeg_dng test_bigtiff_roundtrip open_dng_alloc_fail
 endif
 
 # Test scripts to execute
@@ -400,6 +400,9 @@ threadpool_alloc_fail_SOURCES = threadpool_alloc_fail.c failalloc.c
 threadpool_alloc_fail_LDADD = $(LIBTIFF)
 threadpool_init_fail_SOURCES = threadpool_init_fail.c failalloc.c
 threadpool_init_fail_LDADD = $(LIBTIFF)
+
+open_dng_alloc_fail_SOURCES = open_dng_alloc_fail.c failalloc.c
+open_dng_alloc_fail_LDADD = $(LIBTIFF)
 
 AM_CPPFLAGS = -I$(top_srcdir)/libtiff
 

--- a/test/open_dng_alloc_fail.c
+++ b/test/open_dng_alloc_fail.c
@@ -1,0 +1,41 @@
+#include "failalloc.h"
+#include "tiffio.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+int main(void)
+{
+    const char *dng_rel = "images/TEST_CINEPI_LIBTIFF_DNG.dng";
+    char *srcdir = getenv("srcdir");
+    if (!srcdir)
+        srcdir = ".";
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s", srcdir, dng_rel);
+
+    /* Simulate failure on first malloc when opening */
+    setenv("FAIL_MALLOC_COUNT", "1", 1);
+    failalloc_reset_from_env();
+    TIFF *tif = TIFFOpen(path, "r");
+    if (tif)
+    {
+        fprintf(stderr, "Expected TIFFOpen to fail with OOM\n");
+        TIFFClose(tif);
+        return 1;
+    }
+
+    /* Open successfully without failure */
+    unsetenv("FAIL_MALLOC_COUNT");
+    failalloc_reset_from_env();
+    tif = TIFFOpen(path, "r");
+    if (!tif)
+    {
+        fprintf(stderr, "Cannot open %s\n", path);
+        return 1;
+    }
+    TIFFClose(tif);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add open_dng_alloc_fail test exercising TIFFOpen failure path using failalloc
- build new test via autotools and CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `srcdir=test build/test/open_dng_alloc_fail`

------
https://chatgpt.com/codex/tasks/task_e_68518b277d6c8321b7e2dbad50c1cc0b