### PR TITLE
Add concurrent TIFF read test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -387,6 +387,12 @@ set_target_properties(uring_thread_stress PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(uring_thread_stress PRIVATE tiff tiff_port)
 list(APPEND simple_tests uring_thread_stress)
 
+add_executable(concurrent_rw ../placeholder.h)
+target_sources(concurrent_rw PRIVATE concurrent_rw.c)
+set_target_properties(concurrent_rw PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(concurrent_rw PRIVATE tiff tiff_port)
+list(APPEND simple_tests concurrent_rw)
+
 add_library(failalloc STATIC failalloc.c)
 
 add_executable(threadpool_alloc_fail ../placeholder.h)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -110,7 +110,7 @@ check_PROGRAMS = \
        bayer_neon_test \
        dng_simd_compare \
        packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize ycbcr_neon_test predictor_sse41_test \
-       test_open_jpeg_dng test_bigtiff_roundtrip open_dng_alloc_fail
+       concurrent_rw test_open_jpeg_dng test_bigtiff_roundtrip open_dng_alloc_fail
 endif
 
 # Test scripts to execute
@@ -400,6 +400,9 @@ threadpool_alloc_fail_SOURCES = threadpool_alloc_fail.c failalloc.c
 threadpool_alloc_fail_LDADD = $(LIBTIFF)
 threadpool_init_fail_SOURCES = threadpool_init_fail.c failalloc.c
 threadpool_init_fail_LDADD = $(LIBTIFF)
+
+concurrent_rw_SOURCES = concurrent_rw.c
+concurrent_rw_LDADD = $(LIBTIFF)
 
 open_dng_alloc_fail_SOURCES = open_dng_alloc_fail.c failalloc.c
 open_dng_alloc_fail_LDADD = $(LIBTIFF)

--- a/test/concurrent_rw.c
+++ b/test/concurrent_rw.c
@@ -1,0 +1,110 @@
+#include "tif_config.h"
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include "tiffio.h"
+
+#define THREADS 4
+
+typedef struct
+{
+    const char *filename;
+    unsigned long checksum;
+    int ret;
+} ThreadData;
+
+static void *reader(void *arg)
+{
+    ThreadData *data = (ThreadData *)arg;
+    TIFF *tif = TIFFOpen(data->filename, "r");
+    if (!tif)
+    {
+        data->ret = 1;
+        return NULL;
+    }
+    uint32_t width = 0, length = 0;
+    if (!TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &width) ||
+        !TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &length))
+    {
+        TIFFClose(tif);
+        data->ret = 1;
+        return NULL;
+    }
+    tmsize_t scanline = TIFFScanlineSize(tif);
+    unsigned char *buf = (unsigned char *)_TIFFmalloc(scanline);
+    if (!buf)
+    {
+        TIFFClose(tif);
+        data->ret = 1;
+        return NULL;
+    }
+    data->checksum = 0;
+    for (uint32_t row = 0; row < length; row++)
+    {
+        if (TIFFReadScanline(tif, buf, row, 0) < 0)
+        {
+            data->ret = 1;
+            break;
+        }
+        for (tmsize_t i = 0; i < scanline; i++)
+            data->checksum += buf[i];
+    }
+    _TIFFfree(buf);
+    TIFFClose(tif);
+    return NULL;
+}
+
+int main(void)
+{
+    const char *jpeg_rel = "images/TEST_JPEG.jpg";
+    char *srcdir = getenv("srcdir");
+    if (!srcdir)
+        srcdir = ".";
+    char jpeg_path[512];
+    snprintf(jpeg_path, sizeof(jpeg_path), "%s/%s", srcdir, jpeg_rel);
+    const char *script = "gen_bigtiff_from_jpeg.py";
+    char script_path[512];
+    snprintf(script_path, sizeof(script_path), "%s/%s", srcdir, script);
+    const char *tiffcp = "../tools/tiffcp";
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd), "python3 %s %s mt_concurrent.tif %s",
+             script_path, jpeg_path, tiffcp);
+    if (system(cmd) != 0)
+    {
+        fprintf(stderr, "failed to generate TIFF\n");
+        return 1;
+    }
+
+    pthread_t th[THREADS];
+    ThreadData data[THREADS];
+    for (int i = 0; i < THREADS; i++)
+    {
+        data[i].filename = "mt_concurrent.tif";
+        data[i].checksum = 0;
+        data[i].ret = 0;
+        pthread_create(&th[i], NULL, reader, &data[i]);
+    }
+    int failed = 0;
+    unsigned long checksum = 0;
+    for (int i = 0; i < THREADS; i++)
+    {
+        pthread_join(th[i], NULL);
+        if (data[i].ret)
+            failed = 1;
+        if (i == 0)
+            checksum = data[i].checksum;
+        else if (data[i].checksum != checksum)
+            failed = 1;
+    }
+    unlink("mt_concurrent.tif");
+    if (failed)
+    {
+        fprintf(stderr, "concurrent access failed\n");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add new `concurrent_rw` test for multi-threaded TIFF reading
- hook the program into both CMake and Autotools builds

## Testing
- `pre-commit run --files test/concurrent_rw.c test/CMakeLists.txt test/Makefile.am`
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `ctest -R concurrent_rw --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68518dc19a9c83219df7f8b206b30a21