### PR TITLE
Add TIFFClientOpen stream unit test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -269,6 +269,12 @@ set_target_properties(test_invalid_callbacks PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(test_invalid_callbacks PRIVATE tiff tiff_port)
 list(APPEND simple_tests test_invalid_callbacks)
 
+add_executable(test_client_open_stream ../placeholder.h)
+target_sources(test_client_open_stream PRIVATE test_client_open_stream.c)
+set_target_properties(test_client_open_stream PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(test_client_open_stream PRIVATE tiff tiff_port)
+list(APPEND simple_tests test_client_open_stream)
+
 add_executable(swab_neon_test ../placeholder.h)
 target_sources(swab_neon_test PRIVATE swab_neon_test.c)
 set_target_properties(swab_neon_test PROPERTIES LINKER_LANGUAGE CXX)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -110,7 +110,7 @@ check_PROGRAMS = \
        bayer_neon_test \
        dng_simd_compare \
        packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize ycbcr_neon_test predictor_sse41_test \
-       concurrent_rw test_open_jpeg_dng test_bigtiff_roundtrip open_dng_alloc_fail
+       concurrent_rw test_open_jpeg_dng test_bigtiff_roundtrip test_client_open_stream open_dng_alloc_fail
 endif
 
 # Test scripts to execute
@@ -381,6 +381,9 @@ test_open_jpeg_dng_LDADD = $(LIBTIFF)
 
 test_bigtiff_roundtrip_SOURCES = test_bigtiff_roundtrip.c
 test_bigtiff_roundtrip_LDADD = $(LIBTIFF)
+
+test_client_open_stream_SOURCES = test_client_open_stream.c
+test_client_open_stream_LDADD = $(LIBTIFF)
 
 predictor_threadpool_benchmark_SOURCES = predictor_threadpool_benchmark.c
 predictor_threadpool_benchmark_LDADD = $(LIBTIFF)

--- a/test/test_client_open_stream.c
+++ b/test/test_client_open_stream.c
@@ -1,0 +1,213 @@
+#include "tif_config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include "tiffio.h"
+
+typedef struct
+{
+    unsigned char *data;
+    size_t size;
+    size_t offset;
+#ifdef HAVE_MMAP
+    int map_called;
+    int unmap_called;
+#endif
+} MemoryStream;
+
+static tmsize_t mem_read(thandle_t fd, void *buf, tmsize_t size)
+{
+    MemoryStream *ms = (MemoryStream *)fd;
+    if (ms->offset + size > ms->size)
+        size = ms->size - ms->offset;
+    memcpy(buf, ms->data + ms->offset, size);
+    ms->offset += size;
+    return size;
+}
+
+static tmsize_t mem_write(thandle_t fd, void *buf, tmsize_t size)
+{
+    (void)fd;
+    (void)buf;
+    (void)size;
+    return (tmsize_t)-1;
+}
+
+static toff_t mem_seek(thandle_t fd, toff_t off, int whence)
+{
+    MemoryStream *ms = (MemoryStream *)fd;
+    size_t new_off;
+    switch (whence)
+    {
+    case SEEK_SET:
+        new_off = off;
+        break;
+    case SEEK_CUR:
+        new_off = ms->offset + off;
+        break;
+    case SEEK_END:
+        new_off = ms->size + off;
+        break;
+    default:
+        return (toff_t)-1;
+    }
+    if (new_off > ms->size)
+        return (toff_t)-1;
+    ms->offset = new_off;
+    return ms->offset;
+}
+
+static int mem_close(thandle_t fd)
+{
+    MemoryStream *ms = (MemoryStream *)fd;
+    free(ms->data);
+    free(ms);
+    return 0;
+}
+
+static toff_t mem_size(thandle_t fd)
+{
+    MemoryStream *ms = (MemoryStream *)fd;
+    return (toff_t)ms->size;
+}
+
+#ifdef HAVE_MMAP
+static int mem_map(thandle_t fd, void **pbase, toff_t *psize)
+{
+    MemoryStream *ms = (MemoryStream *)fd;
+    *pbase = ms->data;
+    *psize = ms->size;
+    ms->map_called++;
+    return 1;
+}
+
+static void mem_unmap(thandle_t fd, void *base, toff_t size)
+{
+    MemoryStream *ms = (MemoryStream *)fd;
+    (void)base;
+    (void)size;
+    ms->unmap_called++;
+}
+#endif
+
+static MemoryStream *memory_stream_from_file(const char *filename)
+{
+    FILE *f = fopen(filename, "rb");
+    if (!f)
+        return NULL;
+    if (fseek(f, 0, SEEK_END) != 0)
+    {
+        fclose(f);
+        return NULL;
+    }
+    long size_long = ftell(f);
+    if (size_long < 0)
+    {
+        fclose(f);
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0)
+    {
+        fclose(f);
+        return NULL;
+    }
+    MemoryStream *ms = (MemoryStream *)calloc(1, sizeof(MemoryStream));
+    if (!ms)
+    {
+        fclose(f);
+        return NULL;
+    }
+    ms->size = (size_t)size_long;
+    ms->data = (unsigned char *)malloc(ms->size);
+    if (!ms->data)
+    {
+        free(ms);
+        fclose(f);
+        return NULL;
+    }
+    if (fread(ms->data, 1, ms->size, f) != ms->size)
+    {
+        free(ms->data);
+        free(ms);
+        fclose(f);
+        return NULL;
+    }
+    fclose(f);
+    ms->offset = 0;
+#ifdef HAVE_MMAP
+    ms->map_called = 0;
+    ms->unmap_called = 0;
+#endif
+    return ms;
+}
+
+int main(void)
+{
+    const char *srcdir = getenv("srcdir");
+    if (!srcdir)
+        srcdir = ".";
+    char path[1024];
+
+    /* Test opening JPEG sample: should fail */
+    snprintf(path, sizeof(path), "%s/images/TEST_JPEG.jpg", srcdir);
+    MemoryStream *jpeg_stream = memory_stream_from_file(path);
+    if (!jpeg_stream)
+    {
+        fprintf(stderr, "Cannot read %s\n", path);
+        return 1;
+    }
+    TIFF *tif = TIFFClientOpen("memjpeg", "r", (thandle_t)jpeg_stream, mem_read,
+                               mem_write, mem_seek, mem_close, mem_size,
+#ifdef HAVE_MMAP
+                               mem_map, mem_unmap
+#else
+                               NULL, NULL
+#endif
+    );
+    if (tif)
+    {
+        fprintf(stderr, "Unexpectedly opened JPEG as TIFF\n");
+        TIFFClose(tif);
+        return 1;
+    }
+    /* jpeg_stream is closed by libtiff when opening failed */
+
+#ifdef HAVE_MMAP
+    /* Test opening a valid TIFF and check mmap usage */
+    snprintf(path, sizeof(path), "%s/images/miniswhite-1c-1b.tiff", srcdir);
+    MemoryStream *tiff_stream = memory_stream_from_file(path);
+    if (!tiff_stream)
+    {
+        fprintf(stderr, "Cannot read %s\n", path);
+        return 1;
+    }
+    tif = TIFFClientOpen("memtiff", "r", (thandle_t)tiff_stream, mem_read,
+                         mem_write, mem_seek, mem_close, mem_size, mem_map,
+                         mem_unmap);
+    if (!tif)
+    {
+        fprintf(stderr, "Cannot open TIFF via stream\n");
+        return 1;
+    }
+    uint32_t w = 0, h = 0;
+    if (!TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &w) ||
+        !TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &h))
+    {
+        fprintf(stderr, "Cannot read image fields\n");
+        TIFFClose(tif);
+        return 1;
+    }
+    TIFFClose(tif);
+    if (tiff_stream->map_called == 0 || tiff_stream->unmap_called == 0)
+    {
+        fprintf(stderr, "Memory map callbacks not called\n");
+        return 1;
+    }
+#endif
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a new test using TIFFClientOpen with custom callbacks
- verify mmap callbacks when available
- wire the test into the build system for CMake and Autotools

## Testing
- `cmake --build . -j$(nproc) test_client_open_stream`
- `ctest -R test_client_open_stream --output-on-failure`
- `ctest --output-on-failure` *(fails: TEST_JPEG_BIG not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518fdc6ed08321bba64860d108b68e