### PR TITLE
Add doc coverage checker for new tests

### DIFF
--- a/doc/doc_coverage_policy.rst
+++ b/doc/doc_coverage_policy.rst
@@ -1,0 +1,16 @@
+Documentation Coverage Policy
+=============================
+
+New tests should exercise public APIs covered in the reference
+manual. The ``scripts/test_doc_coverage.py`` helper scans the specified
+C sources for uses of exported functions declared in ``tiffio.h`` and
+reports any that lack a corresponding ``.rst`` page under
+``doc/functions``.
+
+Policy
+------
+
+* CI may invoke ``test_doc_coverage.py`` on newly added tests.
+  Missing documentation for used APIs will cause the job to fail.
+* Add a ``doc/functions/<API>.rst`` page before exercising a new API
+  in the test suite.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -67,6 +67,7 @@ The following sections are included in this documentation:
     tools
     contrib
     vectorization_policy
+    doc_coverage_policy
     rfcs/index
     project/index
     releases/index

--- a/scripts/test_doc_coverage.py
+++ b/scripts/test_doc_coverage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Report undocumented APIs used in test files.
+
+Usage::
+    python3 scripts/test_doc_coverage.py <test.c> [...]
+
+The script scans ``tiffio.h`` for exported function declarations,
+collects those used in the provided test sources and checks that an
+``.rst`` page exists under ``doc/functions`` for each. It exits with a
+non‑zero status if any used API lacks documentation.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def exported_api_names() -> set[str]:
+    """Return names of exported functions declared in ``tiffio.h``."""
+    header = Path("libtiff") / "tiffio.h"
+    text = header.read_text(errors="ignore")
+    pattern = re.compile(r"\bextern\b[^\n]*?\b(\w+)\s*\(")
+    return {m.group(1) for m in pattern.finditer(text) if not m.group(1).startswith("_")}
+
+
+def documented_api_names() -> set[str]:
+    """Return names documented under ``doc/functions``."""
+    return {p.stem for p in Path("doc/functions").glob("*.rst")}
+
+
+def used_api_names(files: list[Path], exported: set[str]) -> set[str]:
+    """Return exported API names used in the given files."""
+    if not exported:
+        return set()
+    pattern = re.compile(r"\b(" + "|".join(map(re.escape, sorted(exported))) + r")\b")
+    names: set[str] = set()
+    for path in files:
+        text = path.read_text(errors="ignore")
+        names.update(pattern.findall(text))
+    return names
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: test_doc_coverage.py <test.c> [...]", file=sys.stderr)
+        return 2
+
+    test_files = [Path(a) for a in argv]
+    exported = exported_api_names()
+    documented = documented_api_names()
+    used = used_api_names(test_files, exported)
+    missing = sorted(used - documented)
+
+    if missing:
+        print("Missing documentation for:")
+        for name in missing:
+            print(f"  {name}")
+        return 1
+
+    print("All used APIs are documented.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add script `test_doc_coverage.py` to check documentation for API usage in tests
- document policy for test documentation coverage
- link the new policy page from the documentation index

## Testing
- `python3 -m py_compile scripts/test_doc_coverage.py`
- `python3 scripts/test_doc_coverage.py test/ascii_tag.c`
- `python3 scripts/test_doc_coverage.py test/test_directory.c | head`

------
https://chatgpt.com/codex/tasks/task_e_685195c95a688321ae22fc64d9e11a9a