### PR TITLE
Add missing API documentation

### DIFF
--- a/doc/functions/TIFFCheckpointDirectory.rst
+++ b/doc/functions/TIFFCheckpointDirectory.rst
@@ -1,0 +1,28 @@
+TIFFCheckpointDirectory
+=======================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFCheckpointDirectory(TIFF* tif)
+
+Description
+-----------
+
+The :c:func:`TIFFCheckpointDirectory` writes the current state of the
+TIFF directory to the file so that what is already written becomes
+readable. Unlike :c:func:`TIFFWriteDirectory`, it does not free the
+directory information in memory so that it may be updated and written
+again later.
+
+See also
+--------
+
+:doc:`TIFFWriteDirectory` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFClientdata.rst
+++ b/doc/functions/TIFFClientdata.rst
@@ -1,0 +1,26 @@
+TIFFClientdata
+==============
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: thandle_t TIFFClientdata(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFClientdata` returns the client data handle associated with an
+open TIFF file. This value represents the underlying file descriptor or
+handle used by ``libtiff``.
+
+See also
+--------
+
+:doc:`TIFFOpen` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFCreateEXIFDirectory.rst
+++ b/doc/functions/TIFFCreateEXIFDirectory.rst
@@ -1,0 +1,26 @@
+TIFFCreateEXIFDirectory
+=======================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFCreateEXIFDirectory(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFCreateEXIFDirectory` sets up the predefined EXIF custom
+directory for the given TIFF handle so that subsequent calls to
+:c:func:`TIFFSetField` populate that directory.
+
+See also
+--------
+
+:doc:`TIFFCustomDirectory` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFCurrentDirOffset.rst
+++ b/doc/functions/TIFFCurrentDirOffset.rst
@@ -1,0 +1,26 @@
+TIFFCurrentDirOffset
+====================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: uint64_t TIFFCurrentDirOffset(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFCurrentDirOffset` returns the file offset of the current
+directory. This value can be passed to :c:func:`TIFFSetSubDirectory` to
+access subdirectories linked through a ``SubIFD`` tag.
+
+See also
+--------
+
+:doc:`TIFFquery` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFCurrentDirectory.rst
+++ b/doc/functions/TIFFCurrentDirectory.rst
@@ -1,0 +1,27 @@
+TIFFCurrentDirectory
+====================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: tdir_t TIFFCurrentDirectory(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFCurrentDirectory` returns the index of the current
+:ref:`Image File Directory (IFD) <ImageFileDirectory>` for the provided
+TIFF handle.
+
+See also
+--------
+
+:doc:`TIFFSetDirectory` (3tiff),
+:doc:`TIFFquery` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFGetReadProc.rst
+++ b/doc/functions/TIFFGetReadProc.rst
@@ -1,0 +1,25 @@
+TIFFGetReadProc
+===============
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: TIFFReadWriteProc TIFFGetReadProc(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFGetReadProc` returns a pointer to the routine used by
+``libtiff`` to read from the specified TIFF handle.
+
+See also
+--------
+
+:doc:`TIFFProcFunctions` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFGetSeekProc.rst
+++ b/doc/functions/TIFFGetSeekProc.rst
@@ -1,0 +1,25 @@
+TIFFGetSeekProc
+===============
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: TIFFSeekProc TIFFGetSeekProc(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFGetSeekProc` returns a pointer to the routine used by
+``libtiff`` to seek within the specified TIFF handle.
+
+See also
+--------
+
+:doc:`TIFFProcFunctions` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFGetWriteProc.rst
+++ b/doc/functions/TIFFGetWriteProc.rst
@@ -1,0 +1,25 @@
+TIFFGetWriteProc
+================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: TIFFReadWriteProc TIFFGetWriteProc(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFGetWriteProc` returns a pointer to the routine used by
+``libtiff`` to write to the specified TIFF handle.
+
+See also
+--------
+
+:doc:`TIFFProcFunctions` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFIsBigEndian.rst
+++ b/doc/functions/TIFFIsBigEndian.rst
@@ -1,0 +1,25 @@
+TIFFIsBigEndian
+===============
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFIsBigEndian(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFIsBigEndian` returns a non-zero value if the TIFF file is
+stored in big-endian byte order and zero if it is little-endian.
+
+See also
+--------
+
+:doc:`TIFFquery` (3tiff),
+:doc:`libtiff` (3tiff)


### PR DESCRIPTION
## Summary
- document TIFFCheckpointDirectory
- document TIFFClientdata
- document TIFFCreateEXIFDirectory
- document TIFFCurrentDirOffset
- document TIFFCurrentDirectory
- document TIFFGetReadProc
- document TIFFGetSeekProc
- document TIFFGetWriteProc
- document TIFFIsBigEndian

## Testing
- `python3 scripts/test_doc_coverage.py test/test_directory.c`

------
https://chatgpt.com/codex/tasks/task_e_68519792300083218015004355f6b94a