### PR TITLE
Add missing doc pages for directory test coverage

### DIFF
--- a/doc/functions/TIFFIsBigTIFF.rst
+++ b/doc/functions/TIFFIsBigTIFF.rst
@@ -1,0 +1,25 @@
+TIFFIsBigTIFF
+=============
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFIsBigTIFF(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFIsBigTIFF` returns a non-zero value if the TIFF file uses the
+BigTIFF format.
+
+See also
+--------
+
+:doc:`TIFFquery` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFIsByteSwapped.rst
+++ b/doc/functions/TIFFIsByteSwapped.rst
@@ -1,0 +1,25 @@
+TIFFIsByteSwapped
+=================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFIsByteSwapped(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFIsByteSwapped` returns a non-zero value if the image data in
+the file uses a different byte order than the host machine.
+
+See also
+--------
+
+:doc:`TIFFquery` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFNumberOfDirectories.rst
+++ b/doc/functions/TIFFNumberOfDirectories.rst
@@ -1,0 +1,25 @@
+TIFFNumberOfDirectories
+======================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: tdir_t TIFFNumberOfDirectories(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFNumberOfDirectories` returns the number of directories in a
+TIFF file.
+
+See also
+--------
+
+:doc:`TIFFquery` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFReadCustomDirectory.rst
+++ b/doc/functions/TIFFReadCustomDirectory.rst
@@ -1,0 +1,26 @@
+TIFFReadCustomDirectory
+======================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFReadCustomDirectory(TIFF* tif, toff_t diroff, const TIFFFieldArray* infoarray)
+
+Description
+-----------
+
+:c:func:`TIFFReadCustomDirectory` reads a custom directory from an
+arbitrary file offset and sets the context of the TIFF handle
+accordingly.
+
+See also
+--------
+
+:doc:`TIFFCustomDirectory` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFReadEXIFDirectory.rst
+++ b/doc/functions/TIFFReadEXIFDirectory.rst
@@ -1,0 +1,25 @@
+TIFFReadEXIFDirectory
+====================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFReadEXIFDirectory(TIFF* tif, toff_t diroff)
+
+Description
+-----------
+
+:c:func:`TIFFReadEXIFDirectory` reads an EXIF directory from the given
+offset.
+
+See also
+--------
+
+:doc:`TIFFCustomDirectory` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFRewriteDirectory.rst
+++ b/doc/functions/TIFFRewriteDirectory.rst
@@ -1,0 +1,25 @@
+TIFFRewriteDirectory
+====================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFRewriteDirectory(TIFF* tif)
+
+Description
+-----------
+
+:c:func:`TIFFRewriteDirectory` rewrites the current directory in place
+without creating a new one.
+
+See also
+--------
+
+:doc:`TIFFWriteDirectory` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFSetSubDirectory.rst
+++ b/doc/functions/TIFFSetSubDirectory.rst
@@ -1,0 +1,25 @@
+TIFFSetSubDirectory
+===================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFSetSubDirectory(TIFF* tif, uint64_t diroff)
+
+Description
+-----------
+
+:c:func:`TIFFSetSubDirectory` changes the current directory to the one at
+the specified file offset.
+
+See also
+--------
+
+:doc:`TIFFSetDirectory` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFSwabLong.rst
+++ b/doc/functions/TIFFSwabLong.rst
@@ -1,0 +1,25 @@
+TIFFSwabLong
+============
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: void TIFFSwabLong(uint32_t* data)
+
+Description
+-----------
+
+:c:func:`TIFFSwabLong` swaps the bytes in a 32-bit value pointed to by
+*data*.
+
+See also
+--------
+
+:doc:`TIFFswab` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFSwabShort.rst
+++ b/doc/functions/TIFFSwabShort.rst
@@ -1,0 +1,25 @@
+TIFFSwabShort
+=============
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: void TIFFSwabShort(uint16_t* data)
+
+Description
+-----------
+
+:c:func:`TIFFSwabShort` swaps the bytes in a 16-bit value pointed to by
+*data*.
+
+See also
+--------
+
+:doc:`TIFFswab` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFUnlinkDirectory.rst
+++ b/doc/functions/TIFFUnlinkDirectory.rst
@@ -1,0 +1,25 @@
+TIFFUnlinkDirectory
+===================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFUnlinkDirectory(TIFF* tif, tdir_t dirn)
+
+Description
+-----------
+
+:c:func:`TIFFUnlinkDirectory` removes the specified directory from the
+TIFF file.
+
+See also
+--------
+
+:doc:`TIFFCreateDirectory` (3tiff),
+:doc:`libtiff` (3tiff)

--- a/doc/functions/TIFFWriteCustomDirectory.rst
+++ b/doc/functions/TIFFWriteCustomDirectory.rst
@@ -1,0 +1,25 @@
+TIFFWriteCustomDirectory
+=======================
+
+Synopsis
+--------
+
+.. highlight:: c
+
+::
+
+    #include <tiffio.h>
+
+.. c:function:: int TIFFWriteCustomDirectory(TIFF* tif, uint64 *pdiroff)
+
+Description
+-----------
+
+:c:func:`TIFFWriteCustomDirectory` writes the current custom directory to
+the file and returns its offset in *pdiroff*.
+
+See also
+--------
+
+:doc:`TIFFCustomDirectory` (3tiff),
+:doc:`libtiff` (3tiff)


### PR DESCRIPTION
## Summary
- add doc pages for TIFF APIs used in test_directory.c
- ensure `scripts/test_doc_coverage.py` passes

## Testing
- `python3 scripts/test_doc_coverage.py test/test_directory.c`

------
https://chatgpt.com/codex/tasks/task_e_68519af0dab88321acda3e2647e919a8