### PR TITLE
Add pipeline tool test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -760,6 +760,11 @@ if(tiff-tools)
   # Test extracting the first and fourth quarters from the left side.
   add_convert_tests(tiffcrop  extractz14 "-E left -Z1:4,2:4"        TIFFIMAGES TRUE)
 
+  add_test(NAME "pipeline-full"
+           COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/pipeline_full_test.sh")
+  set_tests_properties("pipeline-full" PROPERTIES ENVIRONMENT
+          "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
+
   # addtiffo default overview levels
   add_test(NAME "addtiffo-default-small"
            COMMAND "${CMAKE_COMMAND}"

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -141,9 +141,10 @@ BASE_TESTSCRIPTS = \
 	tiff2ps-PS1.sh \
 	tiff2ps-PS2.sh \
 	tiff2ps-PS3.sh \
-	tiff2ps-EPS1.sh \
+        tiff2ps-EPS1.sh \
         tiff2pdf.sh \
         tools-jpeg-dng.sh \
+        pipeline_full_test.sh \
         tiffcrop-doubleflip-logluv-3c-16b.sh \
 	tiffcrop-doubleflip-minisblack-1c-16b.sh \
 	tiffcrop-doubleflip-minisblack-1c-8b.sh \

--- a/test/pipeline_full_test.sh
+++ b/test/pipeline_full_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+#
+# Run a pipeline of libtiff tools: tiffcp -> tiffcrop -> tiff2rgba -> tiffdump
+# Validate the final TIFF file with tiffinfo.
+#
+. ${srcdir:-.}/common.sh
+
+input="${IMG_RGB_3C_8B}"
+tmpdir=${TMPDIR:-/tmp}
+step1="${tmpdir}/pipeline_step1.tiff"
+step2="${tmpdir}/pipeline_step2.tiff"
+step3="${tmpdir}/pipeline_step3.tiff"
+
+f_test_convert "${TIFFCP} -c lzw" "${input}" "${step1}"
+f_test_convert "${TIFFCROP} -U px -E top -X 20 -Y 20" "${step1}" "${step2}"
+f_test_convert "${TIFF2RGBA}" "${step2}" "${step3}"
+f_test_reader "${TIFFDUMP}" "${step3}"
+f_tiffinfo_validate "${step3}"
+rm -f "${step1}" "${step2}" "${step3}"


### PR DESCRIPTION
## Summary
- add `pipeline_full_test.sh` to exercise tiffcp, tiffcrop, tiff2rgba and tiffdump
- register the script in autotools and CMake test infrastructure

## Testing
- `bash -n test/pipeline_full_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68519c212a348321b96148c3712761b9