### PR TITLE
Add cross SIMD test tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ $ cmake -DCMAKE_TOOLCHAIN_FILE=toolchains/rpi5.cmake \
 ```
 Benchmarking a 10MB image gave about 2x faster compression with `zip:p9:s1` (libdeflate) versus `zip:p9:s0` (zlib).
 
+### Cross testing NEON and SSE
+The `scripts/cross_simd_test.py` helper builds the library for both
+SSE4 and NEON and runs a couple of validation and benchmark tools under
+each build (the NEON binaries execute under `qemu-aarch64`).  Install
+`qemu-user` and the AArch64 cross compiler, then run::
+
+    python3 scripts/cross_simd_test.py
+
 
 ### Autotools
 ```bash

--- a/doc/cross_simd.rst
+++ b/doc/cross_simd.rst
@@ -1,0 +1,20 @@
+Cross Testing NEON and SSE
+==========================
+
+The :file:`scripts/cross_simd_test.py` helper automates building libtiff for both
+SSE4 and NEON and runs a couple of representative tests under each build.  The
+NEON binaries are executed under ``qemu-aarch64`` so the script can be run on an
+x86 host without real ARM hardware.
+
+Running the script requires the ``qemu-user`` package and the AArch64 cross
+compiler suite::
+
+    sudo apt-get install qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+Then simply execute::
+
+    python3 scripts/cross_simd_test.py
+
+It will build two temporary directories, ``build_sse`` and ``build_neon``,
+compile ``bayerbench`` and ``dng_simd_compare`` in each, run them, and print a
+short summary comparing the NEON and SSE performance figures.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,6 +61,7 @@ The following sections are included in this documentation:
     internals
     bayer12neon
     bayer16neon
+    cross_simd
     zipneon
     async_dng
     addingtags

--- a/scripts/cross_simd_test.py
+++ b/scripts/cross_simd_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Cross test NEON and SSE builds.
+
+This script builds libtiff twice: once for SSE4.1/4.2 on the host and
+once for NEON using the AArch64 cross toolchain. It runs ``bayerbench``
+and ``dng_simd_compare`` for both builds. NEON executables are executed
+via ``qemu-aarch64``. Results are printed for easy comparison.
+
+Usage::
+
+    python3 scripts/cross_simd_test.py
+"""
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SSE_BUILD = ROOT / "build_sse"
+NEON_BUILD = ROOT / "build_neon"
+
+
+def run(cmd, cwd=None):
+    print("+", *cmd)
+    result = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+    print(result.stdout)
+    if result.returncode != 0:
+        print(result.stderr)
+    result.check_returncode()
+    return result.stdout
+
+
+def configure_sse():
+    args = [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DHAVE_SSE41=1",
+        "-DHAVE_SSE42=1",
+        "-Djpegls=OFF",
+    ]
+    run(["cmake", "-S", str(ROOT), "-B", str(SSE_BUILD)] + args)
+
+
+def configure_neon():
+    args = [
+        "-DCMAKE_TOOLCHAIN_FILE=toolchains/aarch64.cmake",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DHAVE_NEON=1",
+        "-DHAVE_SSE41=0",
+        "-DHAVE_SSE42=0",
+        "-Djpegls=OFF",
+    ]
+    run(["cmake", "-S", str(ROOT), "-B", str(NEON_BUILD)] + args)
+
+
+def build(path: Path):
+    run(["cmake", "--build", str(path), f"-j{os.cpu_count()}"])
+
+
+def bench(binary: Path, loops=10, qemu=False):
+    if qemu:
+        cmd = ["qemu-aarch64", "-L", "/usr/aarch64-linux-gnu", str(binary), str(loops)]
+    else:
+        cmd = [str(binary), str(loops)]
+    out = run(cmd)
+    pack = re.search(r"pack:\s*([0-9.]+)", out)
+    unpack = re.search(r"unpack:\s*([0-9.]+)", out)
+    return float(pack.group(1)), float(unpack.group(1))
+
+
+def check(binary: Path, qemu=False):
+    if qemu:
+        cmd = ["qemu-aarch64", "-L", "/usr/aarch64-linux-gnu", str(binary)]
+    else:
+        cmd = [str(binary)]
+    run(cmd)
+
+
+def main():
+    if SSE_BUILD.exists():
+        shutil.rmtree(SSE_BUILD)
+    if NEON_BUILD.exists():
+        shutil.rmtree(NEON_BUILD)
+
+    configure_sse()
+    configure_neon()
+    build(SSE_BUILD)
+    build(NEON_BUILD)
+
+    sse_pack, sse_unpack = bench(SSE_BUILD / "tools" / "bayerbench")
+    neon_pack, neon_unpack = bench(NEON_BUILD / "tools" / "bayerbench", qemu=True)
+    check(SSE_BUILD / "test" / "dng_simd_compare")
+    check(NEON_BUILD / "test" / "dng_simd_compare", qemu=True)
+
+    print("\nSummary:\n------")
+    print(f"SSE pack speed : {sse_pack:.2f} MPix/s")
+    print(f"SSE unpack speed : {sse_unpack:.2f} MPix/s")
+    print(f"NEON pack speed : {neon_pack:.2f} MPix/s")
+    print(f"NEON unpack speed : {neon_unpack:.2f} MPix/s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `cross_simd_test.py` script to cross-build and benchmark NEON vs SSE
- document the new tool in `cross_simd.rst`
- reference the doc page from the documentation index
- mention the helper in README

## Testing
- `VERBOSE=TRUE ctest -R pipeline-full --output-on-failure` *(fails: pipeline-full)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5c7819c832195c338916b14b2b6