### PR TITLE
Improve test docs and CharLS detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,9 +366,10 @@ advice flags with `TIFFSetMapSize()` and `TIFFSetMapAdvice()`.
 
 
 ## Testing and Validation
-Configure with testing enabled and run the full suite:
+Configure with testing enabled and run the full suite. Enabling the internal
+thread pool avoids several timeouts during the tests:
 ```bash
-$ cmake -DBUILD_TESTING=ON ..
+$ cmake -DBUILD_TESTING=ON -Dthreadpool=ON ..
 $ cmake --build .
 $ ctest       # or: make check
 ```

--- a/cmake/JPEGLSCodec.cmake
+++ b/cmake/JPEGLSCodec.cmake
@@ -2,7 +2,16 @@
 
 set(JPEGLS_SUPPORT FALSE)
 
-find_package(CharLS)
+find_package(CharLS QUIET)
+if(NOT CharLS_FOUND)
+  # Ubuntu packages ship a lowercase 'charlsConfig.cmake'
+  find_package(charls CONFIG QUIET)
+  if(charls_FOUND)
+    set(CharLS_FOUND TRUE)
+    set(CharLS_INCLUDE_DIRS ${charls_INCLUDE_DIRS})
+    set(CharLS_LIBRARIES charls)
+  endif()
+endif()
 
 option(jpegls "use CharLS (required for JPEG-LS compression)" ${CharLS_FOUND})
 if (jpegls AND CharLS_FOUND)


### PR DESCRIPTION
## Summary
- note threadpool flag in README build instructions
- search for lowercase `charls` CMake package so JPEG-LS support builds

## Testing
- `ctest --output-on-failure -j$(nproc) -I 1,10`

------
https://chatgpt.com/codex/tasks/task_e_68524145325c8321a6cbc7d1b8009a43