### PR TITLE
Update benchmarking results

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -41,3 +41,37 @@ ctest -R pipeline-full --output-on-failure
 ```
 
 The `pipeline-full` test passed successfully with threadpool support enabled.
+
+## Codex Container Environment
+
+The pipeline test was also executed inside the Codex runner. Hardware details
+for this container are listed below.
+
+```
+Linux 14efed69da2a 6.12.13 #1 SMP Thu Mar 13 11:34:50 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
+Architecture:                         x86_64
+CPU op-mode(s):                       32-bit, 64-bit
+Address sizes:                        46 bits physical, 48 bits virtual
+Byte Order:                           Little Endian
+CPU(s):                               5
+On-line CPU(s) list:                  0-4
+Vendor ID:                            GenuineIntel
+Model name:                           Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+BIOS Model name:                        CPU @ 0.0GHz
+BIOS CPU family:                      0
+CPU family:                           6
+Model:                                106
+Thread(s) per core:                   1
+Core(s) per socket:                   5
+Socket(s):                            1
+Stepping:                             6
+BogoMIPS:                             5586.87
+Flags:                                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault pti fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm avx512f avx512dq rdseed adx smap clflushopt avx512cd avx512bw avx512vl xsaveopt xsavec xsaves arat umip md_clear arch_capabilities
+Hypervisor vendor:                    KVM
+Virtualization type:                  full
+               total        used        free      shared  buff/cache   available
+Mem:           9.9Gi       320Mi       8.9Gi        44Ki       876Mi       9.6Gi
+Swap:             0B          0B          0B
+```
+
+The `pipeline-full` test passed successfully in this environment as well.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ unpack: 1661.60 MPix/s
 pack:   757.83 MPix/s
 unpack: 1188.53 MPix/s
 
+# Codex runner results
+pack:   405.00 MPix/s
+unpack: 405.34 MPix/s
+
 $ ./test/swab_benchmark
 TIFFSwabArrayOfShort: 0.011 ms
 scalar_swab_short:    0.004 ms
@@ -331,6 +335,13 @@ TIFFSwabArrayOfLong:  0.016 ms
 scalar_swab_long:     0.014 ms
 TIFFSwabArrayOfLong8: 0.028 ms
 scalar_swab_long8:    0.025 ms
+# Codex runner results
+TIFFSwabArrayOfShort: 0.298 ms
+scalar_swab_short:    0.257 ms
+TIFFSwabArrayOfLong:  0.360 ms
+scalar_swab_long:     0.360 ms
+TIFFSwabArrayOfLong8: 0.655 ms
+scalar_swab_long8:    0.617 ms
 ```
 ARM NEON builds on an RK3588 at 2.4 GHz show roughly 6× improvements for
 `TIFFPackRaw12` and 5× for `TIFFUnpackRaw12`. `TIFFSwabArrayOfLong8` is


### PR DESCRIPTION
## Summary
- record benchmark results from the Codex runner in `BENCHMARK.md`
- document Codex benchmark numbers in `README.md`

## Testing
- `cmake -Dthreadpool=ON -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest -R pipeline-full --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68539c9b47d48321a5d95e9d3b8f2c74