### PR TITLE
Update benchmark docs for SIMD results

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -75,3 +75,48 @@ Swap:             0B          0B          0B
 ```
 
 The `pipeline-full` test passed successfully in this environment as well.
+
+## Additional Codex Container Environment
+
+The tests were run again on another Codex container instance. Details of this
+machine are listed below.
+```
+Linux aeb88f1cfc18 6.12.13 #1 SMP Thu Mar 13 11:34:50 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
+Architecture:                         x86_64
+CPU op-mode(s):                       32-bit, 64-bit
+Address sizes:                        46 bits physical, 48 bits virtual
+Byte Order:                           Little Endian
+CPU(s):                               5
+On-line CPU(s) list:                  0-4
+Vendor ID:                            GenuineIntel
+Model name:                           Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+BIOS Model name:                        CPU @ 0.0GHz
+BIOS CPU family:                      0
+CPU family:                           6
+Model:                                106
+Thread(s) per core:                   1
+Core(s) per socket:                   5
+Socket(s):                            1
+Stepping:                             6
+BogoMIPS:                             5586.87
+Flags:                                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault pti fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm avx512f avx512dq rdseed adx smap clflushopt avx512cd avx512bw avx512vl xsaveopt xsavec xsaves arat umip md_clear arch_capabilities
+Hypervisor vendor:                    KVM
+Virtualization type:                  full
+               total        used        free      shared  buff/cache   available
+Mem:           9.9Gi       324Mi       8.9Gi        44Ki       876Mi       9.6Gi
+Swap:             0B          0B          0B
+```
+
+The `pipeline-full` test succeeded on this instance as well.
+
+## SIMD Benchmark Results
+
+Running the `scripts/cross_simd_test.py` helper validated SSE4.1 and
+NEON builds. The Codex container produced the following summary:
+
+```
+SSE pack speed : 4320.16 MPix/s
+SSE unpack speed : 4265.02 MPix/s
+NEON pack speed : 756.23 MPix/s
+NEON unpack speed : 393.28 MPix/s
+```

--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ pack:   757.83 MPix/s
 unpack: 1188.53 MPix/s
 
 # Codex runner results
-pack:   405.00 MPix/s
-unpack: 405.34 MPix/s
+pack:   389.23 MPix/s
+unpack: 403.40 MPix/s
 
 $ ./test/swab_benchmark
 TIFFSwabArrayOfShort: 0.011 ms
@@ -336,16 +336,27 @@ scalar_swab_long:     0.014 ms
 TIFFSwabArrayOfLong8: 0.028 ms
 scalar_swab_long8:    0.025 ms
 # Codex runner results
-TIFFSwabArrayOfShort: 0.298 ms
-scalar_swab_short:    0.257 ms
+TIFFSwabArrayOfShort: 0.225 ms
+scalar_swab_short:    0.221 ms
 TIFFSwabArrayOfLong:  0.360 ms
-scalar_swab_long:     0.360 ms
-TIFFSwabArrayOfLong8: 0.655 ms
-scalar_swab_long8:    0.617 ms
+scalar_swab_long:     0.384 ms
+TIFFSwabArrayOfLong8: 0.623 ms
+scalar_swab_long8:    0.622 ms
 ```
 ARM NEON builds on an RK3588 at 2.4 GHz show roughly 6× improvements for
 `TIFFPackRaw12` and 5× for `TIFFUnpackRaw12`. `TIFFSwabArrayOfLong8` is
 around 3× faster than the scalar implementation on the same device.
+
+Running `scripts/cross_simd_test.py` on the Codex container confirmed
+the SIMD paths. Example summary:
+
+```bash
+$ python3 scripts/cross_simd_test.py
+SSE pack speed : 4320.16 MPix/s
+SSE unpack speed : 4265.02 MPix/s
+NEON pack speed : 756.23 MPix/s
+NEON unpack speed : 393.28 MPix/s
+```
 
 ## Thread Pool Usage
 


### PR DESCRIPTION
## Summary
- document cross_simd_test output in README and BENCHMARK.md
- include SSE/NEON performance numbers from Codex container

## Testing
- `cmake -Dthreadpool=ON -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest -R pipeline-full --output-on-failure`
- `python3 scripts/cross_simd_test.py`


------
https://chatgpt.com/codex/tasks/task_e_6853a4b3216c832180030b6be02641f9