### PR TITLE
Add Python helper tests and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,9 +407,31 @@ $ cmake --build .
 $ ctest       # or: make check
 ```
 Additional programs validate SIMD helpers individually:
-- `assemble_strip_neon_test` writes and reads a small image to verify strip assembly【F:test/assemble_strip_neon_test.c†L8-L68】.
+- `assemble_strip_neon_test` writes and reads a small image to verify strip assembly.
 - `swab_neon_test` checks byte swapping correctness.
 - `swab_benchmark` reports timing for NEON vs. scalar swapping.
+- `bayer_neon_test` validates NEON Bayer packing and unpacking.
+- `gray_flip_neon_test` exercises NEON optimized grayscale flipping.
+- `rgb_pack_neon_test` checks NEON RGB packing helpers.
+- `reverse_bits_neon_test` verifies NEON bit reversal routines.
+- `memmove_simd_test` covers the vectorized `memmove` implementation.
+- `ycbcr_neon_test` validates NEON YCbCr color conversion.
+- `predictor_sse41_test` runs the SSE4.1 predictor path.
+- `dng_simd_compare` compares NEON and SSE decode results.
+- `bayer_pack_test` ensures scalar and SIMD Bayer packing match.
+- `bayer_simd_benchmark` measures Bayer SIMD performance.
+- `predictor_threadpool_benchmark` times thread pool predictor code.
+- `pack_uring_benchmark` benchmarks asynchronous I/O packing.
+- `tiffstream_api` exercises the C++ stream interface (`TIFFStreamOpen`).
+- `tiff_fdopen_async` opens one TIFF via file descriptor on multiple
+  threads using `std::async`.
+- `scripts/cross_simd_test.py` compares SSE4.1 and NEON implementations.
+- `scripts/run_all_benchmarks.py` builds the project and summarises all
+  benchmarks.
+- `scripts/vectorization_audit.py` lists loops that failed automatic
+  vectorization.
+- `scripts/test_doc_coverage.py` ensures used APIs have matching
+  documentation.
 All SIMD helpers must pass the same tests as the scalar implementations.
 
 ## Contributing

--- a/doc/benchmark_results_explained.md
+++ b/doc/benchmark_results_explained.md
@@ -41,6 +41,20 @@ sense of relative performance between scalar implementations and their
 SIMD or multi-threaded counterparts.
 
 Additional tools exercised by the script verify NEON and SSE4.1 helpers
-such as `assemble_strip_neon_test`, `rgb_pack_neon_test` and
-`predictor_sse41_test`.  These programs do not print timings but return
+such as `assemble_strip_neon_test`, `rgb_pack_neon_test`,
+`bayer_neon_test`, `gray_flip_neon_test`, `reverse_bits_neon_test`,
+`memmove_simd_test`, `ycbcr_neon_test`, `dng_simd_compare` and
+`predictor_sse41_test`. These programs do not print timings but return
 zero on success which is reported as `status: ok` in the summary.
+Tests for the C++ bindings include `tiffstream_api`, while
+`tiff_fdopen_async` exercises `TIFFFdOpen` from multiple threads using
+`std::async`.
+
+Other utilities assist with performance analysis and documentation:
+
+- `scripts/cross_simd_test.py` cross-compiles for SSE4.1 and NEON and
+  runs representative benchmarks under both builds.
+- `scripts/vectorization_audit.py` builds with clang and lists loops the
+  vectorizer failed to optimize.
+- `scripts/test_doc_coverage.py` checks that newly added tests call only
+  documented public APIs.

--- a/scripts/tests/test_parse_results.py
+++ b/scripts/tests/test_parse_results.py
@@ -1,0 +1,21 @@
+import os, sys; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import pytest
+from scripts.run_all_benchmarks import parse_results
+
+
+def test_parse_numeric_results():
+    output = "TIFFSwabArrayOfShort: 0.181 ms\nscalar_swab_short: 0.158 ms"
+    res = parse_results(output)
+    assert res == {
+        "TIFFSwabArrayOfShort (ms)": 0.181,
+        "scalar_swab_short (ms)": 0.158,
+    }
+
+
+def test_parse_status_ok():
+    assert parse_results("") == {"status": "ok"}
+
+
+def test_parse_generic_output():
+    text = "Something happened"
+    assert parse_results(text) == {"output": text}

--- a/scripts/tests/test_parse_results_async.py
+++ b/scripts/tests/test_parse_results_async.py
@@ -1,0 +1,19 @@
+import os, sys; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import asyncio
+from scripts.run_all_benchmarks import parse_results
+
+async def parse_async(text):
+    return parse_results(text)
+
+def test_async_parse_concurrent():
+    async def gather():
+        outs = [
+            "TIFFSwabArrayOfShort: 1.0 ms",
+            "scalar_swab_short: 0.8 ms",
+        ]
+        results = await asyncio.gather(*(parse_async(o) for o in outs))
+        assert results[0]["TIFFSwabArrayOfShort (ms)"] == 1.0
+        assert results[1]["scalar_swab_short (ms)"] == 0.8
+
+    asyncio.run(gather())
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,14 @@ if(JPEG_SUPPORT)
     list(APPEND TIFFIMAGES images/quad-tile.jpg.tiff)
 endif()
 
+add_test(NAME parse_results_pytest
+         COMMAND python3 -m pytest -q
+         ${CMAKE_SOURCE_DIR}/scripts/tests/test_parse_results.py)
+
+add_test(NAME parse_results_async_pytest
+         COMMAND python3 -m pytest -q
+         ${CMAKE_SOURCE_DIR}/scripts/tests/test_parse_results_async.py)
+
 if (OJPEG_SUPPORT)
     list(APPEND TIFFIMAGES_OJPEG
         images/ojpeg_zackthecat_subsamp22_single_strip.tiff
@@ -420,6 +428,18 @@ add_executable(open_dng_alloc_fail ../placeholder.h)
 target_sources(open_dng_alloc_fail PRIVATE open_dng_alloc_fail.c)
 target_link_libraries(open_dng_alloc_fail PRIVATE tiff tiff_port failalloc)
 list(APPEND simple_tests open_dng_alloc_fail)
+
+add_executable(tiffstream_api ../placeholder.h)
+target_sources(tiffstream_api PRIVATE tiffstream_api.cpp)
+set_target_properties(tiffstream_api PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(tiffstream_api PRIVATE tiffxx tiff tiff_port)
+list(APPEND simple_tests tiffstream_api)
+
+add_executable(tiff_fdopen_async ../placeholder.h)
+target_sources(tiff_fdopen_async PRIVATE tiff_fdopen_async.cpp)
+set_target_properties(tiff_fdopen_async PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(tiff_fdopen_async PRIVATE tiffxx tiff tiff_port)
+list(APPEND simple_tests tiff_fdopen_async)
 
 if(WEBP_SUPPORT AND EMSCRIPTEN)
   # Emscripten is pretty finnicky about linker flags.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -110,7 +110,8 @@ check_PROGRAMS = \
        bayer_neon_test \
        dng_simd_compare \
        packbits_literal_run threadpool_stress uring_thread_stress threadpool_alloc_fail threadpool_init_fail assemble_strip_neon_alloc_fail predictor_threadpool_resize ycbcr_neon_test predictor_sse41_test \
-       concurrent_rw test_open_jpeg_dng test_bigtiff_roundtrip test_client_open_stream open_dng_alloc_fail
+       concurrent_rw test_open_jpeg_dng test_bigtiff_roundtrip test_client_open_stream open_dng_alloc_fail tiffstream_api
+       tiff_fdopen_async
 endif
 
 # Test scripts to execute
@@ -410,6 +411,12 @@ concurrent_rw_LDADD = $(LIBTIFF)
 
 open_dng_alloc_fail_SOURCES = open_dng_alloc_fail.c failalloc.c
 open_dng_alloc_fail_LDADD = $(LIBTIFF)
+
+tiffstream_api_SOURCES = tiffstream_api.cpp
+tiffstream_api_LDADD = $(LIBTIFF)
+
+tiff_fdopen_async_SOURCES = tiff_fdopen_async.cpp
+tiff_fdopen_async_LDADD = $(LIBTIFF)
 
 AM_CPPFLAGS = -I$(top_srcdir)/libtiff
 

--- a/test/tiff_fdopen_async.cpp
+++ b/test/tiff_fdopen_async.cpp
@@ -1,0 +1,44 @@
+#include "tiffio.hxx"
+#include <cstdio>
+#include <cstdlib>
+#include <fcntl.h>
+#include <future>
+#include <unistd.h>
+
+static int check_via_fd(const char *path)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+    {
+        perror("open");
+        return 1;
+    }
+    TIFF *tif = TIFFFdOpen(fd, path, "r");
+    if (!tif)
+    {
+        close(fd);
+        fprintf(stderr, "TIFFFdOpen failed\n");
+        return 1;
+    }
+    uint32_t w = 0, h = 0;
+    int ok = TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &w) &&
+             TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &h);
+    TIFFClose(tif);
+    return ok && w > 0 && h > 0 ? 0 : 1;
+}
+
+int main()
+{
+    const char *srcdir = getenv("srcdir");
+    if (!srcdir)
+        srcdir = ".";
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/images/rgb-3c-8b.tiff", srcdir);
+
+    auto f1 = std::async(std::launch::async, check_via_fd, path);
+    auto f2 = std::async(std::launch::async, check_via_fd, path);
+    auto f3 = std::async(std::launch::async, check_via_fd, path);
+    auto f4 = std::async(std::launch::async, check_via_fd, path);
+
+    return f1.get() || f2.get() || f3.get() || f4.get();
+}

--- a/test/tiffstream_api.cpp
+++ b/test/tiffstream_api.cpp
@@ -1,0 +1,35 @@
+#include "tiffio.hxx"
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+
+int main()
+{
+    const char *srcdir = getenv("srcdir");
+    if (!srcdir)
+        srcdir = ".";
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/images/rgb-3c-8b.tiff", srcdir);
+    std::ifstream is(path, std::ios::binary);
+    if (!is.is_open())
+    {
+        fprintf(stderr, "Cannot open %s\n", path);
+        return 1;
+    }
+    TIFF *tif = TIFFStreamOpen("stream", &is);
+    if (!tif)
+    {
+        fprintf(stderr, "TIFFStreamOpen failed\n");
+        return 1;
+    }
+    uint32_t width = 0, length = 0;
+    if (!TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &width) ||
+        !TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &length))
+    {
+        fprintf(stderr, "Missing tags\n");
+        TIFFClose(tif);
+        return 1;
+    }
+    TIFFClose(tif);
+    return (width > 0 && length > 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- document Python benchmarking helpers in README and benchmark overview
- include vectorization and doc coverage utilities
- add pytest for `parse_results` helper and integrate via CMake
- add `tiffstream_api` C++ test exercising TIFFStreamOpen
- add asynchronous TIFF file descriptor test and async Python test

## Testing
- `pre-commit run --files README.md doc/benchmark_results_explained.md test/CMakeLists.txt test/Makefile.am test/tiff_fdopen_async.cpp scripts/tests/test_parse_results_async.py`
- `pytest scripts/tests/test_parse_results.py scripts/tests/test_parse_results_async.py -q`
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build -j$(nproc)`
- `ctest -R parse_results -VV`


------
https://chatgpt.com/codex/tasks/task_e_6853db21d8588321b5021109b22796c4