### PR TITLE
Add resolution speed tester

### DIFF
--- a/scripts/resolution_speed_test.py
+++ b/scripts/resolution_speed_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Measure TIFF encode/decode speed at various resolutions."""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+try:
+    from PIL import Image  # type: ignore
+    HAVE_PIL = True
+except Exception:
+    HAVE_PIL = False
+
+DEFAULT_RESOLUTIONS = [
+    (640, 480),
+    (1280, 720),
+    (1920, 1080),
+]
+
+
+def parse_resolution(text: str):
+    parts = text.lower().split("x")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("resolution must be WxH")
+    return int(parts[0]), int(parts[1])
+
+
+def generate_image(width: int, height: int) -> "Image.Image":
+    pixels = os.urandom(width * height * 3)
+    return Image.frombytes("RGB", (width, height), pixels)
+
+
+def measure_speed(width: int, height: int, frames: int, outdir: Path):
+    img = generate_image(width, height)
+    path = outdir / f"{width}x{height}.tiff"
+
+    start = time.perf_counter()
+    for _ in range(frames):
+        img.save(path, format="TIFF")
+    write_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(frames):
+        Image.open(path).load()
+    read_time = time.perf_counter() - start
+
+    fps_write = frames / write_time if write_time else 0.0
+    fps_read = frames / read_time if read_time else 0.0
+    return fps_write, fps_read
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--res",
+        action="append",
+        type=parse_resolution,
+        help="resolution as WxH; can be repeated",
+    )
+    parser.add_argument("--frames", type=int, default=5, help="frames per test")
+    parser.add_argument(
+        "--outdir", type=Path, default=Path("speed_test_images"), help="output directory"
+    )
+    args = parser.parse_args()
+
+    if not HAVE_PIL:
+        print("Pillow not available; skipping speed test.", file=sys.stderr)
+        return
+
+    resolutions = args.res or DEFAULT_RESOLUTIONS
+    args.outdir.mkdir(exist_ok=True)
+
+    for w, h in resolutions:
+        write_fps, read_fps = measure_speed(w, h, args.frames, args.outdir)
+        print(f"{w}x{h}")
+        print(f"  write_fps: {write_fps:.2f}")
+        print(f"  read_fps:  {read_fps:.2f}")
+        # Additional lines used by run_all_benchmarks.parse_results
+        print(f"write_fps_{w}x{h}: {write_fps:.2f} fps")
+        print(f"read_fps_{w}x{h}: {read_fps:.2f} fps")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_all_benchmarks.py
+++ b/scripts/run_all_benchmarks.py
@@ -58,7 +58,7 @@ def parse_results(out):
     if out is None:
         return results
     for line in out.splitlines():
-        m = re.search(r"([A-Za-z0-9_+]+):?\s*([0-9.]+)\s*(ms|MPix/s)?", line)
+        m = re.search(r"([A-Za-z0-9_+]+):?\s*([0-9.]+)\s*(ms|MPix/s|fps)?", line)
         if m:
             key = m.group(1)
             val = float(m.group(2))
@@ -100,6 +100,12 @@ def main():
         print(f"Running {rel}...")
         out = run_bench(rel, args)
         summary[rel] = parse_results(out)
+
+    speed_script = ROOT / "scripts" / "resolution_speed_test.py"
+    if speed_script.exists():
+        print("Running resolution_speed_test.py...")
+        out = run([sys.executable, str(speed_script), "--frames", "2"])
+        summary["resolution_speed_test"] = parse_results(out)
 
     print("\nBenchmark summary:\n------------------")
     for prog, res in summary.items():

--- a/scripts/tests/test_parse_results.py
+++ b/scripts/tests/test_parse_results.py
@@ -12,6 +12,15 @@ def test_parse_numeric_results():
     }
 
 
+def test_parse_fps_results():
+    text = "write_fps_640x480: 30.5 fps\nread_fps_640x480: 28.1 fps"
+    res = parse_results(text)
+    assert res == {
+        "write_fps_640x480 (fps)": 30.5,
+        "read_fps_640x480 (fps)": 28.1,
+    }
+
+
 def test_parse_status_ok():
     assert parse_results("") == {"status": "ok"}
 

--- a/scripts/tests/test_resolution_speed.py
+++ b/scripts/tests/test_resolution_speed.py
@@ -1,0 +1,18 @@
+import os, sys
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "resolution_speed_test.py"
+
+def test_speed_script_runs(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--res", "64x64", "--frames", "2", "--outdir", str(tmp_path)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "64x64" in result.stdout
+    assert "write_fps" in result.stdout
+    assert "read_fps" in result.stdout
+    assert "write_fps_64x64" in result.stdout
+    assert "read_fps_64x64" in result.stdout


### PR DESCRIPTION
## Summary
- add `resolution_speed_test.py` script to measure encode/decode fps
- parse fps output in benchmark runner
- integrate script into `run_all_benchmarks.py`
- expand tests for new output

## Testing
- `pre-commit run --files scripts/resolution_speed_test.py scripts/run_all_benchmarks.py scripts/tests/test_parse_results.py scripts/tests/test_resolution_speed.py`
- `pytest scripts/tests/test_parse_results.py scripts/tests/test_resolution_speed.py -q`
- `python3 scripts/resolution_speed_test.py --res 64x64 --frames 2`

------
https://chatgpt.com/codex/tasks/task_e_6853ee42d32c8321aa288d47c6b06936