### PR TITLE
Document and expose HVS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ processing images.
 
 On DRM-enabled systems, the library can also offload color space conversion
 through the HVS pipeline. Configure with `-Ddrm-hvs=ON` or
-`--enable-drm-hvs` and call `TIFFSetUseHVS(1)` before reading images.
+`--enable-drm-hvs` and initialize the subsystem with `TIFFInitHVS()`.  Enable
+hardware processing by calling `TIFFSetUseHVS(1)` before reading images.
 
 ## How to Use SIMD Routines
 Below is a short example that assembles a 12‑bit strip and writes a DNG.
@@ -301,6 +302,15 @@ _TIFFThreadPoolWait(pool);
 _tiffUringWait(tif);
 free(s);
 free(tmp);
+```
+
+Enable the HVS unit to offload colour conversion when decoding the generated
+DNG:
+
+```c
+TIFFInitHVS();
+TIFFSetUseHVS(1);
+TIFFReadRGBAImageHVS(tif, width, height, raster, ORIENTATION_BOTLEFT, 0);
 ```
 
 See [doc/async_dng.rst](doc/async_dng.rst) for a detailed overview of

--- a/doc/benchmark_results_explained.md
+++ b/doc/benchmark_results_explained.md
@@ -68,3 +68,5 @@ Other utilities assist with performance analysis and documentation:
 - `scripts/test_doc_coverage.py` checks that newly added tests call only
   documented public APIs.
 - `scripts/raw_to_dng_benchmark.py` measures raw to DNG conversion speed using raw2tiff.
+  The test can be combined with the HVS path by building with `-Ddrm-hvs=ON`
+  and setting `TIFFSetUseHVS(1)` in the conversion tool.

--- a/libtiff/libtiff.def
+++ b/libtiff/libtiff.def
@@ -217,6 +217,8 @@ EXPORTS	TIFFAccessTagMethods
         TIFFInitSIMD
         TIFFInitVulkan
         TIFFCleanupVulkan
+        TIFFInitHVS
+        TIFFCleanupHVS
         TIFFUseNEON
         TIFFUseSSE41
         TIFFUseSSE2

--- a/libtiff/libtiff.map
+++ b/libtiff/libtiff.map
@@ -250,6 +250,8 @@ LIBTIFF_4.7.1 {
     TIFFInitSIMD;
     TIFFInitVulkan;
     TIFFCleanupVulkan;
+    TIFFInitHVS;
+    TIFFCleanupHVS;
     tiff_use_neon;
     tiff_use_sse41;
     tiff_use_sse2;

--- a/libtiff/tif_hvs.c
+++ b/libtiff/tif_hvs.c
@@ -8,6 +8,26 @@
 #include <xf86drmMode.h>
 
 int tiff_use_hvs = 0;
+static int tiff_hvs_fd = -1;
+
+void TIFFInitHVS(void)
+{
+    if (tiff_use_hvs)
+        return;
+    tiff_hvs_fd = open("/dev/dri/card0", O_RDWR);
+    if (tiff_hvs_fd >= 0)
+        tiff_use_hvs = 1;
+}
+
+void TIFFCleanupHVS(void)
+{
+    if (tiff_hvs_fd >= 0)
+    {
+        close(tiff_hvs_fd);
+        tiff_hvs_fd = -1;
+    }
+    tiff_use_hvs = 0;
+}
 
 int TIFFUseHVS(void) { return tiff_use_hvs; }
 
@@ -50,6 +70,10 @@ int tiff_use_hvs = 0;
 int TIFFUseHVS(void) { return 0; }
 
 void TIFFSetUseHVS(int enable) { (void)enable; }
+
+void TIFFInitHVS(void) {}
+
+void TIFFCleanupHVS(void) {}
 
 int TIFFReadRGBAImageHVS(TIFF *tif, uint32_t width, uint32_t height,
                          uint32_t *raster, int orientation, int stopOnError)

--- a/libtiff/tiff_hvs.h
+++ b/libtiff/tiff_hvs.h
@@ -14,12 +14,16 @@ extern "C" {
 extern int tiff_use_hvs;
 int TIFFUseHVS(void);
 void TIFFSetUseHVS(int enable);
+void TIFFInitHVS(void);
+void TIFFCleanupHVS(void);
 int TIFFReadRGBAImageHVS(TIFF *tif, uint32_t width, uint32_t height,
                          uint32_t *raster, int orientation, int stopOnError);
 #else
 extern int tiff_use_hvs;
 int TIFFUseHVS(void);
 void TIFFSetUseHVS(int enable);
+void TIFFInitHVS(void);
+void TIFFCleanupHVS(void);
 int TIFFReadRGBAImageHVS(TIFF *tif, uint32_t width, uint32_t height,
                          uint32_t *raster, int orientation, int stopOnError);
 #endif


### PR DESCRIPTION
## Summary
- document using `TIFFInitHVS` and `TIFFSetUseHVS`
- export HVS initialization helpers in the public API
- describe HVS usage in benchmark docs

## Testing
- `pre-commit` *(fails: command not found)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb0539c083218a010ad1c9923cef