### PR TITLE
Add io_uring + thread pool TLA+ model

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,6 +65,8 @@ The following sections are included in this documentation:
     zipneon
     zipaes
     async_dng
+    threadpool_verification
+    uring_threadpool_verification
     addingtags
     tools
     contrib

--- a/doc/uring_threadpool_spec.cfg
+++ b/doc/uring_threadpool_spec.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+INVARIANTS InvNoOverlap InvQueueBound InvRingBound

--- a/doc/uring_threadpool_spec.tla
+++ b/doc/uring_threadpool_spec.tla
@@ -1,0 +1,49 @@
+---- MODULE uring_threadpool_spec ----
+EXTENDS Naturals, Sequences
+
+CONSTANTS Buffers, Workers, RingDepth, PoolMax
+
+VARIABLES queue, inUse, ring, completed
+
+Init == /\ queue = << >>
+         /\ inUse = {}
+         /\ ring = << >>
+         /\ completed = {}
+
+Submit(buf) == /\ buf \in Buffers
+                /\ Len(queue) < PoolMax
+                /\ queue' = Append(queue, buf)
+                /\ UNCHANGED <<inUse, ring, completed>>
+
+StartWork(buf) == /\ Len(queue) > 0
+                   /\ buf = Head(queue)
+                   /\ queue' = Tail(queue)
+                   /\ inUse' = inUse \cup {buf}
+                   /\ UNCHANGED <<ring, completed>>
+
+FinishWork(buf) == /\ buf \in inUse
+                    /\ Len(ring) < RingDepth
+                    /\ inUse' = inUse \ {buf}
+                    /\ ring' = Append(ring, buf)
+                    /\ UNCHANGED <<queue, completed>>
+
+RingComplete(buf) == /\ Len(ring) > 0
+                       /\ buf = Head(ring)
+                       /\ ring' = Tail(ring)
+                       /\ completed' = completed \cup {buf}
+                       /\ UNCHANGED <<queue, inUse>>
+
+Next == \E buf \in Buffers :
+            Submit(buf)
+            \/ StartWork(buf)
+            \/ FinishWork(buf)
+            \/ RingComplete(buf)
+
+Spec == Init /\ [][Next]_<<queue, inUse, ring, completed>>
+
+InvNoOverlap == \A buf \in Buffers : ~(buf \in inUse /\ buf \in ring)
+InvQueueBound == Len(queue) <= PoolMax
+InvRingBound == Len(ring) <= RingDepth
+
+THEOREM Spec => [](InvNoOverlap /\ InvQueueBound /\ InvRingBound)
+====

--- a/doc/uring_threadpool_verification.rst
+++ b/doc/uring_threadpool_verification.rst
@@ -1,0 +1,16 @@
+Asynchronous IO and Thread Pool Specification
+=============================================
+
+The file :file:`uring_threadpool_spec.tla` models the interaction between
+libtiff's thread pool workers and the ``io_uring`` submission/completion loop.
+It tracks buffers as they move from the work queue to asynchronous writes and
+verifies that a buffer is never simultaneously being processed by a worker and
+queued for ``io_uring``.
+
+Install the `TLA+ tools <https://github.com/tlaplus/tlaplus/releases>`_
+locally and run ``tlc``::
+
+  tlc uring_threadpool_spec.tla -config uring_threadpool_spec.cfg
+
+``TLC`` will exhaustively check that the invariants in the model hold for all
+reachable states.


### PR DESCRIPTION
## Summary
- formal TLA+ spec for buffer life-cycle between thread pool and io_uring
- configuration file and documentation explaining how to run the model
- index both verification docs so they're visible in the manual

## Testing
- `pre-commit run --files doc/uring_threadpool_spec.tla doc/uring_threadpool_spec.cfg doc/uring_threadpool_verification.rst doc/index.rst`
- `ctest` *(fails: No test configuration file found)*
- `cmake ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(incomplete due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68550ffa061c832189761d4e52ee4589