### PR TITLE
Document contributor in license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,3 +525,5 @@ Including `tiff_simd.h` exposes `TIFF_SIMD_ENABLED`, `TIFF_SIMD_NEON` and
 
 ## License
 This fork inherits the original [libtiff license](LICENSE.md).
+Additional optimizations and improvements are © 2025 Jules Le Masson Fletcher and
+released under the same license.


### PR DESCRIPTION
## Summary
- add Jules Le Masson Fletcher credit in license section

## Testing
- `pre-commit run --files README.md`
- `cmake -S . -B builddir -DCMAKE_BUILD_TYPE=Release`
- `cmake --build builddir -j$(nproc)`
- `ctest --test-dir builddir --output-on-failure -j $(nproc)` *(fails: test_open_options, pack_uring_benchmark, tiffcp-dng-none, tiffcp-dng-lzw)*

------
https://chatgpt.com/codex/tasks/task_e_685519beac6083219adffbfadce41ac1