### PR TITLE
Run tests, audit, benchmark and fix warning

### DIFF
--- a/libtiff/tif_dir.c
+++ b/libtiff/tif_dir.c
@@ -703,7 +703,7 @@ static int _TIFFVSetField(TIFF *tif, uint32_t tag, va_list ap)
         default:
         {
             TIFFTagValue *tv;
-            int tv_size, iCustom;
+            int tv_size;
 
             /*
              * This can happen if multiple images are open with different
@@ -743,7 +743,6 @@ static int _TIFFVSetField(TIFF *tif, uint32_t tag, va_list ap)
             tv = TIFFCustomValueLookup(td, tag);
             if (tv != NULL)
             {
-                iCustom = (int)(tv - td->td_customValues);
                 if (tv->value != NULL)
                 {
                     _TIFFfreeExt(tif, tv->value);


### PR DESCRIPTION
## Summary
- fix unused variable warning in `tif_dir.c`
- ran unit test `ascii_tag`
- executed `swab_benchmark`
- ran `vectorization_audit.py` and `run_flawfinder.py`

## Testing
- `ctest -R ascii_tag -V`
- `./build-release/test/swab_benchmark`
- `python3 scripts/vectorization_audit.py`
- `python3 scripts/run_flawfinder.py`

------
https://chatgpt.com/codex/tasks/task_e_68551e4a0a4c8321937a8f514585be0c