### PR TITLE
Fix custom_dir infinite loop

### DIFF
--- a/libtiff/tif_dirread.c
+++ b/libtiff/tif_dirread.c
@@ -5667,6 +5667,9 @@ int _TIFFCheckDirNumberAndOffset(TIFF *tif, tdir_t dirn, uint64_t diroff)
     if (diroff == 0) /* no more directories */
         return 0;
 
+    if (dirn == TIFF_NON_EXISTENT_DIR_NUMBER)
+        return 1;
+
     /* Update cache of directory offsets */
     if (dirn >= tif->tif_dir_offset_cache_count)
     {


### PR DESCRIPTION
## Summary
- avoid unbounded doubling in `_TIFFCheckDirNumberAndOffset`
- `custom_dir` test now completes

## Testing
- `ctest -R "^custom_dir$" --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68552374b60483218d1c29377b90ef9d