### PR TITLE
Improve benchmark parsing

### DIFF
--- a/scripts/run_all_benchmarks.py
+++ b/scripts/run_all_benchmarks.py
@@ -65,7 +65,12 @@ def parse_results(out):
         m = re.search(r"([A-Za-z0-9_+]+):?\s*([0-9.]+)\s*(ms|MPix/s|fps)?", line)
         if m:
             key = m.group(1)
-            val = float(m.group(2))
+            try:
+                val = float(m.group(2))
+            except ValueError:
+                # Skip entries where the numeric portion isn't actually a
+                # number (for example error messages like "TIFFOpen:")
+                continue
             unit = m.group(3) or ""
             results[f"{key} ({unit.strip()})"] = val
     if not results:


### PR DESCRIPTION
## Summary
- skip lines without numeric values when parsing benchmark output

## Testing
- `pre-commit run --files scripts/run_all_benchmarks.py`
- `ctest --output-on-failure`
- `python3 scripts/run_all_benchmarks.py`

------
https://chatgpt.com/codex/tasks/task_e_68553d7aa6c883218e71717bfc8ed774