### PR TITLE
Fix benchmark summary parsing

### DIFF
--- a/scripts/run_all_benchmarks.py
+++ b/scripts/run_all_benchmarks.py
@@ -62,7 +62,7 @@ def parse_results(out):
     if out is None:
         return results
     for line in out.splitlines():
-        m = re.search(r"([A-Za-z0-9_+]+):?\s*([0-9.]+)\s*(ms|MPix/s|fps)?", line)
+        m = re.search(r"([A-Za-z0-9_+x-]+):\s*([0-9.e+-]+)\s*(ms|MPix/s|fps)?", line)
         if m:
             key = m.group(1)
             try:


### PR DESCRIPTION
## Summary
- correct regex in `run_all_benchmarks.py` so resolutions are parsed

## Testing
- `pre-commit run --files scripts/run_all_benchmarks.py`
- `python3 scripts/run_all_benchmarks.py`

------
https://chatgpt.com/codex/tasks/task_e_68554021b9a083218003d4e749ba6a58