### PR TITLE
Run tests and fix warning in NEON alloc test

### DIFF
--- a/test/assemble_strip_neon_alloc_fail.c
+++ b/test/assemble_strip_neon_alloc_fail.c
@@ -22,6 +22,7 @@ int main(void)
     TIFFErrorHandlerExt prev = TIFFSetErrorHandlerExt(myErrorHandler);
     const char *mod =
         TIFFUseSSE41() ? "TIFFAssembleStripSSE41" : "TIFFAssembleStripNEON";
+    (void)mod;
 
     /* Failure of first allocation */
     setenv("FAIL_MALLOC_COUNT", "1", 1);


### PR DESCRIPTION
## Summary
- fix an unused variable warning in `assemble_strip_neon_alloc_fail`
- run the full CMake test suite

## Testing
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure`
- `./test/swab_benchmark 100000 10`
- `./test/bayer_simd_benchmark`

------
https://chatgpt.com/codex/tasks/task_e_685541707ab483218b450fcad7e9296a