### PR TITLE
Fix C++ stream reader

### DIFF
--- a/contrib/stream/tiffstream.h
+++ b/contrib/stream/tiffstream.h
@@ -3,6 +3,7 @@
 #ifndef _TIFF_STREAM_H_
 #define _TIFF_STREAM_H_
 
+#include <cstddef>
 #include <iostream>
 
 #include "tiffio.h"
@@ -42,7 +43,7 @@ class TiffStream
   public:
     // query method
     TIFF *getTiffHandle() const { return m_tif; }
-    unsigned int getStreamLength() const { return m_streamLength; }
+    std::size_t getStreamLength() const { return m_streamLength; }
 
   private:
     // internal methods
@@ -58,7 +59,7 @@ class TiffStream
     std::istream *m_inStream;
     std::ostream *m_outStream;
     std::iostream *m_ioStream;
-    int m_streamLength;
+    std::size_t m_streamLength;
 };
 
 #endif // _TIFF_STREAM_H_

--- a/test/tiff_fdopen_async.cpp
+++ b/test/tiff_fdopen_async.cpp
@@ -1,9 +1,9 @@
 #include "tiffio.hxx"
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <fcntl.h>
 #include <future>
-#include <array>
 #include <memory>
 #include <string>
 #include <unistd.h>
@@ -17,7 +17,7 @@ static int check_via_fd(const char *path)
         return 1;
     }
     std::unique_ptr<TIFF, decltype(&TIFFClose)> tif(TIFFFdOpen(fd, path, "r"),
-                                                   &TIFFClose);
+                                                    &TIFFClose);
     if (!tif)
     {
         close(fd);


### PR DESCRIPTION
## Summary
- guard reads against overflow in `TiffStream::read`
- track stream length with `std::size_t`
- apply formatting fixes

## Testing
- `pre-commit run --files contrib/stream/tiffstream.cpp contrib/stream/tiffstream.h test/tiff_fdopen_async.cpp`
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build . -j$(nproc)`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68554405025c832194df59c649388d81