### PR TITLE
Fix C++ stream interface

### DIFF
--- a/contrib/stream/tiffstream.cpp
+++ b/contrib/stream/tiffstream.cpp
@@ -151,7 +151,7 @@ int TiffStream::map(thandle_t /*fd*/, tdata_t * /*phase*/, toff_t * /*psize*/)
     return 0;
 }
 
-void TiffStream::unmap(thandle_t /*fd*/, tdata_t /*base*/, tsize_t /*size*/) {}
+void TiffStream::unmap(thandle_t /*fd*/, tdata_t /*base*/, toff_t /*size*/) {}
 
 std::uint64_t TiffStream::getSize(thandle_t fd)
 {
@@ -204,6 +204,8 @@ bool TiffStream::seekInt(thandle_t fd, std::uint64_t offset, int origin)
         case end:
             org = std::ios::end;
             break;
+        default:
+            return false;
     }
 
     TiffStream *ts = reinterpret_cast<TiffStream *>(fd);

--- a/contrib/stream/tiffstream.h
+++ b/contrib/stream/tiffstream.h
@@ -39,7 +39,7 @@ class TiffStream
     static toff_t size(thandle_t fd);
     static int close(thandle_t fd);
     static int map(thandle_t fd, tdata_t *phase, toff_t *psize);
-    static void unmap(thandle_t fd, tdata_t base, tsize_t size);
+    static void unmap(thandle_t fd, tdata_t base, toff_t size);
 
   public:
     // query method


### PR DESCRIPTION
## Summary
- fix `unmap` signature to match libtiff prototype
- avoid uninitialized switch variable in `seekInt`

## Testing
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68554a4ba2588321ad2a7d2896bfba9b