### PR TITLE
Improve C++ cleanup handling

### DIFF
--- a/contrib/stream/tiffstream.cpp
+++ b/contrib/stream/tiffstream.cpp
@@ -18,12 +18,15 @@ TiffStream::TiffStream()
     m_streamLength = 0;
 
     m_this = reinterpret_cast<thandle_t>(this);
-};
+}
 
 TiffStream::~TiffStream()
 {
     if (m_tif != nullptr)
+    {
         TIFFClose(m_tif);
+        m_tif = nullptr;
+    }
 }
 
 TIFF *TiffStream::makeFileStream(std::istream *str)
@@ -134,16 +137,19 @@ int TiffStream::close(thandle_t fd)
     if (ts->m_inStream != nullptr)
     {
         ts->m_inStream = nullptr;
+        ts->m_tif = nullptr;
         return 0;
     }
     else if (ts->m_outStream != nullptr)
     {
         ts->m_outStream = nullptr;
+        ts->m_tif = nullptr;
         return 0;
     }
     else if (ts->m_ioStream != nullptr)
     {
         ts->m_ioStream = nullptr;
+        ts->m_tif = nullptr;
         return 0;
     }
     return -1;
@@ -201,7 +207,8 @@ bool TiffStream::seekInt(thandle_t fd, std::uint64_t offset, int origin)
     if (!isOpen(fd))
         return false;
 
-    if (offset > static_cast<std::uint64_t>(std::numeric_limits<std::streamoff>::max()))
+    if (offset >
+        static_cast<std::uint64_t>(std::numeric_limits<std::streamoff>::max()))
         return false;
 
     std::ios::seekdir org;

--- a/contrib/win_dib/Tiffile.cpp
+++ b/contrib/win_dib/Tiffile.cpp
@@ -10,7 +10,7 @@
 /*--------------------------------------------------------------------
         READ TIFF
         Load the TIFF data from the file into memory.  Return
-        a pointer to a valid DIB (or NULL for errors).
+        a pointer to a valid DIB (or nullptr for errors).
         Uses the TIFFRGBA interface to libtiff.lib to convert
         most file formats to a usable form.  We just keep the 32 bit
         form of the data to display, rather than optimizing for the
@@ -22,7 +22,7 @@
             PVOID ReadTIFF ( LPCTSTR lpszPath )
 
         RETURN
-            A valid DIB pointer for success; NULL for failure.
+            A valid DIB pointer for success; nullptr for failure.
 
   --------------------------------------------------------------------*/
 
@@ -64,8 +64,8 @@ int ChkTIFF(LPCTSTR lpszPath)
     TIFFErrorHandler eh;
     TIFFErrorHandler wh;
 
-    eh = TIFFSetErrorHandler(NULL);
-    wh = TIFFSetWarningHandler(NULL);
+    eh = TIFFSetErrorHandler(nullptr);
+    wh = TIFFSetWarningHandler(nullptr);
 
     std::unique_ptr<TIFF, decltype(&TIFFClose)> tif(TIFFOpen(lpszPath, "r"),
                                                     &TIFFClose);
@@ -84,15 +84,15 @@ void DibInstallHack(TIFFDibImage *img);
 
 PVOID ReadTIFF(LPCTSTR lpszPath)
 {
-    void *pDIB = 0;
+    void *pDIB = nullptr;
     TIFFErrorHandler wh;
 
     wh = TIFFSetWarningHandler(MyWarningHandler);
 
     if (ChkTIFF(lpszPath))
     {
-        std::unique_ptr<TIFF, decltype(&TIFFClose)> tif(
-            TIFFOpen(lpszPath, "r"), &TIFFClose);
+        std::unique_ptr<TIFF, decltype(&TIFFClose)> tif(TIFFOpen(lpszPath, "r"),
+                                                        &TIFFClose);
         if (tif)
         {
             std::array<char, 1024> emsg{};
@@ -131,7 +131,7 @@ PVOID ReadTIFF(LPCTSTR lpszPath)
 
 HANDLE TIFFRGBA2DIB(TIFFDibImage *dib, uint32_t *raster)
 {
-    void *pDIB = 0;
+    void *pDIB = nullptr;
     TIFFRGBAImage *img = &dib->tif;
 
     uint32_t imageLength;
@@ -170,9 +170,9 @@ HANDLE TIFFRGBA2DIB(TIFFDibImage *dib, uint32_t *raster)
 
         // Allocate for the BITMAPINFO structure and the color table.
         pDIB = GlobalAllocPtr(GHND, dwDIBSize);
-        if (pDIB == 0)
+        if (pDIB == nullptr)
         {
-            return (NULL);
+            return nullptr;
         }
 
         // Copy the header info
@@ -229,9 +229,9 @@ HANDLE TIFFRGBA2DIB(TIFFDibImage *dib, uint32_t *raster)
 
         // Allocate for the BITMAPINFO structure and the color table.
         pDIB = GlobalAllocPtr(GHND, dwDIBSize);
-        if (pDIB == 0)
+        if (pDIB == nullptr)
         {
-            return (NULL);
+            return nullptr;
         }
 
         // Copy the header info


### PR DESCRIPTION
## Summary
- modernize Windows DIB helper by using `nullptr`
- fix minor RAII issues in `TiffStream`

## Testing
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68554f4d81808321a5e1f5b68943656f