### PR TITLE
Audit and improve C++ stream handling

### DIFF
--- a/libtiff/tif_stream.cxx
+++ b/libtiff/tif_stream.cxx
@@ -28,7 +28,10 @@
 #include "tiffiop.h"
 #include <iostream>
 
-using namespace std;
+using std::ios;
+using std::istream;
+using std::ostream;
+using std::streamsize;
 
 /*
   ISO C++ uses a 'std::streamsize' type to define counts.  This makes
@@ -354,6 +357,8 @@ extern "C"
                 return nullptr;
             data->stream = reinterpret_cast<ostream *>(fd);
             data->start_pos = data->stream->tellp();
+            if (data->start_pos == ios::pos_type(-1))
+                data->start_pos = ios::pos_type(0);
 
             // Open for writing.
             tif = TIFFClientOpen(
@@ -372,6 +377,8 @@ extern "C"
                 return nullptr;
             data->stream = reinterpret_cast<istream *>(fd);
             data->start_pos = data->stream->tellg();
+            if (data->start_pos == ios::pos_type(-1))
+                data->start_pos = ios::pos_type(0);
             // Open for reading.
             tif = TIFFClientOpen(
                 name, mode, reinterpret_cast<thandle_t>(data), _tiffisReadProc,


### PR DESCRIPTION
## Summary
- avoid `using namespace std` in tif_stream.cxx
- handle invalid stream positions when opening streams

## Testing
- `cmake -DBUILD_TESTING=ON ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6855587e558c83218c1a96616b5ab19b