### PR TITLE
Improve C++ fuzzer build and formatting

### DIFF
--- a/contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc
+++ b/contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc
@@ -24,10 +24,11 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <sstream>
-#include <vector>
 #include <tiffio.h>
 #include <tiffio.hxx>
+#include <vector>
 
 /* stolen from tiffiop.h, which is a private header so we can't just include it
  */

--- a/contrib/win_dib/Tiffile.cpp
+++ b/contrib/win_dib/Tiffile.cpp
@@ -178,9 +178,8 @@ HANDLE TIFFRGBA2DIB(TIFFDibImage *dib, uint32_t *raster)
         *reinterpret_cast<BITMAPINFOHEADER *>(pDIB) = bi;
 
         // Get a pointer to the color table
-        RGBQUAD *pRgbq =
-            reinterpret_cast<RGBQUAD *>(static_cast<LPSTR>(pDIB) +
-                                        sizeof(BITMAPINFOHEADER));
+        RGBQUAD *pRgbq = reinterpret_cast<RGBQUAD *>(static_cast<LPSTR>(pDIB) +
+                                                     sizeof(BITMAPINFOHEADER));
 
         pRgbq[0].rgbRed = 0;
         pRgbq[0].rgbBlue = 0;
@@ -235,9 +234,8 @@ HANDLE TIFFRGBA2DIB(TIFFDibImage *dib, uint32_t *raster)
         *reinterpret_cast<BITMAPINFOHEADER *>(pDIB) = bi;
 
         // Get a pointer to the color table
-        RGBQUAD *pRgbq =
-            reinterpret_cast<RGBQUAD *>(static_cast<LPSTR>(pDIB) +
-                                        sizeof(BITMAPINFOHEADER));
+        RGBQUAD *pRgbq = reinterpret_cast<RGBQUAD *>(static_cast<LPSTR>(pDIB) +
+                                                     sizeof(BITMAPINFOHEADER));
 
         // Pointers to the bits
         // PVOID pbiBits = (LPSTR)pRgbq + bi.biClrUsed * sizeof(RGBQUAD);


### PR DESCRIPTION
## Summary
- include `<memory>` in the OSS-Fuzz fuzzer
- format WinDIB sample code with clang-format

## Testing
- `pre-commit run --files contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc contrib/win_dib/Tiffile.cpp`
- `cmake --build build_dir -j $(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68555bab1bc8832198a7d0be04ec558d